### PR TITLE
feat(html): support dialog closedby attribute

### DIFF
--- a/rabbita/html/attrs.mbt
+++ b/rabbita/html/attrs.mbt
@@ -238,6 +238,17 @@ pub fn Attrs::class(self : Attrs, value : String) -> Attrs {
 }
 
 ///|
+/// Set the dialog `closedby` attribute.
+///
+/// Browser support is limited. Rabbita only emits the attribute; it does not
+/// polyfill dismissal behavior. Values include `"none"`, `"closerequest"`,
+/// and `"any"`.
+/// [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy)
+pub fn Attrs::closedby(self : Attrs, value : String) -> Attrs {
+  self.attribute("closedby", value)
+}
+
+///|
 /// [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/color)
 pub fn Attrs::color(self : Attrs, value : String) -> Attrs {
   self.attribute("color", value)

--- a/rabbita/html/dialog_test.mbt
+++ b/rabbita/html/dialog_test.mbt
@@ -1,0 +1,37 @@
+///|
+fn assert_dialog_attr(
+  html : @html.Html,
+  name : String,
+  expected : String,
+) -> Unit raise {
+  match html.to_virtual_dom() {
+    @runtime.VNode::Elem("dialog", props, _, namespace_uri=None) =>
+      match props.attrs.get(name) {
+        Some(actual) if actual == expected => ()
+        Some(actual) => fail("expected \{name}=\{expected}, got \{actual}")
+        None => fail("expected \{name}=\{expected}")
+      }
+    _ => fail("expected dialog element")
+  }
+}
+
+///|
+test "dialog closedby argument emits attribute" {
+  assert_dialog_attr(
+    @html.dialog(closedby="any", @html.nothing),
+    "closedby",
+    "any",
+  )
+}
+
+///|
+test "dialog accepts closedby through attrs builder" {
+  assert_dialog_attr(
+    @html.dialog(
+      attrs=@html.Attrs::build().closedby("closerequest"),
+      @html.nothing,
+    ),
+    "closedby",
+    "closerequest",
+  )
+}

--- a/rabbita/html/html.mbt
+++ b/rabbita/html/html.mbt
@@ -1980,6 +1980,9 @@ pub fn[C : IsChildren] tfoot(
 /// 
 /// - `open`: indicates whether the dialog is open or closed by default.
 /// 
+/// - `closedby`: emits the limited-support browser `closedby` attribute.
+///   Rabbita does not polyfill dismissal behavior.
+///
 /// # Messages
 /// 
 /// - `close`: triggered when the dialog is closed. 
@@ -2034,6 +2037,7 @@ pub fn[C : IsChildren] dialog(
   title? : String,
   hidden? : Bool,
   open? : Bool,
+  closedby? : String,
   on_close? : Emit[String],
   on_cancel? : Cmd,
   attrs? : Attrs,
@@ -2043,6 +2047,7 @@ pub fn[C : IsChildren] dialog(
   push_title(title, attrs)
   push_hidden(hidden, attrs)
   push_open(open, attrs)
+  push_closedby(closedby, attrs)
   push_close(on_close, attrs)
   push_cancel(on_cancel, attrs)
   push_style(style, attrs)

--- a/rabbita/html/html_utils.mbt
+++ b/rabbita/html/html_utils.mbt
@@ -167,6 +167,13 @@ fn push_open(value : Bool?, attrs : Attrs) -> Unit {
 }
 
 ///|
+fn push_closedby(value : String?, attrs : Attrs) -> Unit {
+  if value is Some(v) {
+    ignore(attrs.closedby(v))
+  }
+}
+
+///|
 fn push_datetime(value : String?, attrs : Attrs) -> Unit {
   if value is Some(v) {
     ignore(attrs.attribute("datetime", v))

--- a/rabbita/html/pkg.generated.mbti
+++ b/rabbita/html/pkg.generated.mbti
@@ -64,7 +64,7 @@ pub fn[C : IsChildren] details(style? : Array[String], id? : String, class? : St
 
 pub fn[C : IsChildren] dfn(style? : Array[String], id? : String, class? : String, title? : String, hidden? : Bool, attrs? : Attrs, C) -> Html
 
-pub fn[C : IsChildren] dialog(style? : Array[String], id? : String, class? : String, title? : String, hidden? : Bool, open? : Bool, on_close? : @cmd.Emit[String], on_cancel? : @cmd.Cmd, attrs? : Attrs, C) -> Html
+pub fn[C : IsChildren] dialog(style? : Array[String], id? : String, class? : String, title? : String, hidden? : Bool, open? : Bool, closedby? : String, on_close? : @cmd.Emit[String], on_cancel? : @cmd.Cmd, attrs? : Attrs, C) -> Html
 
 pub fn[C : IsChildren] div(style? : Array[String], id? : String, class? : String, title? : String, hidden? : Bool, on_click? : @cmd.Cmd, on_mousedown? : @cmd.Emit[@common.Mouse], on_mouseup? : @cmd.Emit[@common.Mouse], on_scroll? : @cmd.Emit[@common.Scroll], on_keydown? : @cmd.Emit[@common.Keyboard], on_keyup? : @cmd.Emit[@common.Keyboard], attrs? : Attrs, C) -> Html
 
@@ -336,6 +336,7 @@ pub fn Attrs::charset(Self, String) -> Self
 pub fn Attrs::checked(Self, Bool) -> Self
 pub fn Attrs::cite(Self, String) -> Self
 pub fn Attrs::class(Self, String) -> Self
+pub fn Attrs::closedby(Self, String) -> Self
 pub fn Attrs::color(Self, String) -> Self
 pub fn Attrs::colorspace(Self, String) -> Self
 pub fn Attrs::cols(Self, Int) -> Self


### PR DESCRIPTION
## Summary

- Add `Attrs::closedby(value)` for emitting the native `<dialog closedby="...">` attribute.
- Add `closedby?` to `@html.dialog(...)`.
- Document this as attribute emission only: browser support is limited and Rabbita does not polyfill dismissal behavior.
- Add dedicated html-package tests for both the dialog wrapper argument and attrs builder path.

## Validation

- `moon fmt`
- `moon info`
- `moon check`
- `moon test rabbita/html`

This property is still in [Limited availability](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy), but I want to use this on my site.