### PR TITLE
fix(warren): skip dangling symlinks during discovery

### DIFF
--- a/warren/discover/discover.mbt
+++ b/warren/discover/discover.mbt
@@ -191,13 +191,15 @@ async fn discover_mod(
     let files = @fs.readdir(dir.to_string())
     for file in files {
       let path = dir.join(file)
+      let path_str = path.to_string()
       match file {
         "moon.pkg" =>
           packages.push(
             discover_pkg(dir, mod_root~, mod_name~, mod_artifact_root~),
           )
         "_build" | ".mooncakes" | "node_modules" => ()
-        _ if @fs.kind(path.to_string()) is Directory => queue.push(path)
+        _ if @fs.exists(path_str) && @fs.kind(path_str) is Directory =>
+          queue.push(path)
         _ => ()
       }
     }

--- a/warren/discover/discover_test.mbt
+++ b/warren/discover/discover_test.mbt
@@ -1,0 +1,40 @@
+///|
+async test "discover skips dangling symlinks" {
+  let root_str = "/tmp/warren-discover-dangling-symlink-test"
+  if @fs.exists(root_str) {
+    @fs.rmdir(root_str, recursive=true)
+  }
+  @fs.mkdir(root_str, permission=0o755, recursive=true)
+  let mod_config =
+    #|{
+    #|  "name": "local/discover-test",
+    #|  "version": "0.1.0",
+    #|  "deps": {}
+    #|}
+  @fs.write_file(
+    "\{root_str}/moon.mod.json",
+    mod_config,
+    create=0o644,
+    truncate=true,
+  )
+  let pkg_config =
+    #|options(
+    #|  "is-main": true,
+    #|)
+  @fs.write_file(
+    "\{root_str}/moon.pkg",
+    pkg_config,
+    create=0o644,
+    truncate=true,
+  )
+  @fs.symlink(target="\{root_str}/missing-target", "\{root_str}/dangling-link")
+  match @discover.discover(root_str) {
+    Some({ kind: MoonMod(mod), .. }) =>
+      inspect(mod.packages.length(), content="1")
+    None => inspect("None", content="Some(MoonMod(...))")
+    Some({ kind: MoonWork(_), .. }) => inspect("MoonWork", content="MoonMod")
+    Some({ kind: MoonMbtX(_), .. }) => inspect("MoonMbtX", content="MoonMod")
+    Some({ kind: MoonMbtMd(_), .. }) => inspect("MoonMbtMd", content="MoonMod")
+  }
+  @fs.rmdir(root_str, recursive=true)
+}

--- a/warren/discover/moon.pkg
+++ b/warren/discover/moon.pkg
@@ -5,4 +5,8 @@ import {
   "moonbit-community/warren/configs",
 }
 
+import {
+  "moonbitlang/async",
+} for "test"
+
 supported_targets = "native"


### PR DESCRIPTION
 ## Summary

   Fix Warren discovery so dangling symlinks are skipped instead of crashing traversal.

   `@fs.kind` follows symlinks by default and raises for dangling symlinks. Discovery now checks `@fs.exists(path_str)`
 before calling `@fs.kind(path_str)` while deciding whether to enqueue child directories.

   Adds a regression test for a module containing a dangling symlink.

   Fixes #119.

   ## Validation

   - `cd warren && moon test --target native ./discover`
   - `cd warren && moon check --target native --deny-warn`
   - `cd warren && moon test --target native .`
   - `cd warren && moon info --target native ./discover`
   - `cd warren && moon fmt --check`
   - Manual repro: created a temporary module with a dangling symlink and confirmed `warren build` completes successfully.