### PR TITLE
feat(html): add beforeinput event handler

### DIFF
--- a/rabbita/html/attrs_event.mbt
+++ b/rabbita/html/attrs_event.mbt
@@ -355,6 +355,21 @@ pub fn Attrs::on_wheel(self : Attrs, msg : (WheelEvent) -> Cmd) -> Attrs {
 
 ///|
 #cfg(target="js")
+pub fn Attrs::on_beforeinput(self : Attrs, msg : (InputEvent) -> Cmd) -> Attrs {
+  self.handler("beforeinput", (event, scheduler) => {
+    scheduler.add(msg(event.to_input_event().unwrap()))
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn Attrs::on_beforeinput(self : Attrs, msg : (InputEvent) -> Cmd) -> Attrs {
+  ignore(msg)
+  self
+}
+
+///|
+#cfg(target="js")
 pub fn Attrs::on_input(self : Attrs, msg : (InputEvent) -> Cmd) -> Attrs {
   self.handler("input", (event, scheduler) => {
     scheduler.add(msg(event.to_input_event().unwrap()))

--- a/rabbita/html/pkg.generated.mbti
+++ b/rabbita/html/pkg.generated.mbti
@@ -410,6 +410,7 @@ pub fn Attrs::muted(Self, Bool) -> Self
 pub fn Attrs::name(Self, String) -> Self
 pub fn Attrs::nonce(Self, String) -> Self
 pub fn Attrs::novalidate(Self, Bool) -> Self
+pub fn Attrs::on_beforeinput(Self, (@dom.InputEvent) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_blur(Self, (@dom.FocusEvent) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_change(Self, (@dom.InputEvent) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_click(Self, (@dom.MouseEvent) -> @cmd.Cmd) -> Self


### PR DESCRIPTION
Add `Attrs::on_beforeinput` to handle the DOM [beforeinput event](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforeinput_event), which fires
before the input value is modified. This is essential for intercepting and
cancelling edits (e.g. rich text editors, input validation) that `on_input`
cannot prevent because it fires after the change.

