### PR TITLE
feat(dom): expose Document elementFromPoint and elementsFromPoint

### DIFF
--- a/rabbita/dom/Document.mbt
+++ b/rabbita/dom/Document.mbt
@@ -155,6 +155,28 @@ pub fn Document::get_document_element(self : Self) -> Element? {
 }
 
 ///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint
+#cfg(target="js")
+pub fn Document::element_from_point(
+  self : Self,
+  x : Double,
+  y : Double,
+) -> Element? {
+  ffi_document_element_from_point(self, x, y).to_option()
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint
+#cfg(target="js")
+pub fn Document::elements_from_point(
+  self : Self,
+  x : Double,
+  y : Double,
+) -> Array[Element] {
+  ffi_document_elements_from_point(self, x, y)
+}
+
+///|
 /// https://developer.mozilla.org/en-US/docs/Web/API/Document/hidden
 #cfg(target="js")
 pub extern "js" fn Document::hidden(self : Self) -> Bool = "(doc) => doc.hidden"
@@ -186,3 +208,19 @@ extern "js" fn ffi_document_get_body(
 extern "js" fn ffi_document_get_document_element(
   doc : Document,
 ) -> @js.Nullable[Element] = "(doc) => doc.documentElement"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_document_element_from_point(
+  doc : Document,
+  x : Double,
+  y : Double,
+) -> @js.Nullable[Element] = "(doc, x, y) => doc.elementFromPoint(x, y)"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_document_elements_from_point(
+  doc : Document,
+  x : Double,
+  y : Double,
+) -> Array[Element] = "(doc, x, y) => Array.from(doc.elementsFromPoint(x, y))"

--- a/rabbita/dom/core_primitives_wbtest.mbt
+++ b/rabbita/dom/core_primitives_wbtest.mbt
@@ -52,6 +52,14 @@ extern "js" fn core_primitives_test_document() -> Document =
   #|   head: { nodeType: 1, id: "head" },
   #|   body: { nodeType: 1, id: "body" },
   #|   documentElement: { nodeType: 1, id: "document-element" },
+  #|   elementFromPoint: (x, y) => (
+  #|     x === 12.5 && y === 24.75 ? { nodeType: 1, id: "point" } : null
+  #|   ),
+  #|   elementsFromPoint: (x, y) => (
+  #|     x === 12.5 && y === 24.75
+  #|       ? [{ nodeType: 1, id: "point" }, { nodeType: 1, id: "parent" }]
+  #|       : []
+  #|   ),
   #| })
 
 ///|
@@ -360,6 +368,10 @@ test "element and document core primitives expose browser values" {
   assert_true(document.get_head() is Some(_))
   assert_true(document.get_body() is Some(_))
   assert_true(document.get_document_element() is Some(_))
+  assert_true(document.element_from_point(12.5, 24.75) is Some(_))
+  assert_true(document.element_from_point(12.5, 25.0) is None)
+  assert_eq(document.elements_from_point(12.5, 24.75).length(), 2)
+  assert_eq(document.elements_from_point(12.5, 25.0).length(), 0)
 }
 
 ///|

--- a/rabbita/dom/pkg.generated.mbti
+++ b/rabbita/dom/pkg.generated.mbti
@@ -244,6 +244,8 @@ pub fn Document::create_document_fragment(Self) -> DocumentFragment
 pub fn Document::create_element(Self, String) -> Element
 pub fn Document::create_element_ns(Self, String, String, on_namespace_error? : (DOMException) -> Element, on_invalid_character_error? : (DOMException) -> Element) -> Element
 pub fn Document::create_text_node(Self, String) -> Element
+pub fn Document::element_from_point(Self, Double, Double) -> Element?
+pub fn Document::elements_from_point(Self, Double, Double) -> Array[Element]
 pub fn Document::get_active_element(Self) -> Element?
 pub fn Document::get_body(Self) -> HTMLElement?
 pub fn Document::get_document_element(Self) -> Element?


### PR DESCRIPTION
Add two hit-testing APIs to `Document` that are commonly needed for pointer-driven UI (drag-and-drop, resizable panels, custom tooltips, etc.)

- [`element_from_point(x, y) -> Element?`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint) — returns the topmost element at the given viewport coordinates, or `None` when the point is outside the document or no element exists there.
- [`elements_from_point(x, y) -> Array[Element]`](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint) — returns all elements stacked at the coordinates ordered from topmost to bottommost.
