### PR TITLE
feat(warren)!: support full-stack MoonBit projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _test
 **/_build
 **/node_modules
 **/dist
+.tmp
+**/.DS_Store

--- a/examples/animation/README.md
+++ b/examples/animation/README.md
@@ -16,7 +16,7 @@ In this directory:
 
 ```bash
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -8,7 +8,7 @@ In this directory:
 
 ```sh
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/examples/document/README.md
+++ b/examples/document/README.md
@@ -8,7 +8,7 @@ In this directory:
 
 ```sh
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/examples/document/moon.mod
+++ b/examples/document/moon.mod
@@ -4,7 +4,7 @@ version = "0.2.0"
 
 import {
   "moonbit-community/rabbita@0.12.2",
-  "moonbitlang/async@0.20.3",
+  "moonbitlang/async@0.21.0",
   "oboard/mocket@0.7.7",
 }
 

--- a/examples/grocery/README.md
+++ b/examples/grocery/README.md
@@ -8,7 +8,7 @@ In this directory:
 
 ```sh
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/examples/shiki_editor/README.md
+++ b/examples/shiki_editor/README.md
@@ -19,7 +19,7 @@ In this directory:
 
 ```bash
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/examples/sokoban/README.md
+++ b/examples/sokoban/README.md
@@ -9,5 +9,5 @@ Moving after rewinding truncates future states and appends a new immutable snaps
 
 ```bash
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```

--- a/examples/subscriptions/README.md
+++ b/examples/subscriptions/README.md
@@ -20,7 +20,7 @@ In this directory:
 
 ```bash
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -8,7 +8,7 @@ In this directory:
 
 ```sh
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -26,7 +26,7 @@ In this directory:
 
 ```bash
 moon install moonbit-community/warren
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/rabbita/README.mbt.md
+++ b/rabbita/README.mbt.md
@@ -35,7 +35,7 @@ Make sure you have installed [`moon`](https://www.moonbitlang.com/download/) fir
 moon install moonbit-community/warren
 warren new my-project
 cd my-project
-warren dev
+warren dev --browser-entry main
 ```
 
 See [Warren](./warren/README.md) for more information.

--- a/rabbita/http/op.mbt
+++ b/rabbita/http/op.mbt
@@ -151,8 +151,8 @@ fn request_target(url : String, origin : String) -> (String, String) raise {
 ///|
 fn content_type_headers(
   content_type : String,
-  headers? : Map[String, String] = Map([]),
-) -> Map[String, String] {
+  headers? : @async_http.Headers = Map([]),
+) -> @async_http.Headers {
   if !content_type.is_empty() {
     headers["Content-Type"] = content_type
   }
@@ -161,8 +161,8 @@ fn content_type_headers(
 
 ///|
 #cfg(not(target="js"))
-fn settle_request_headers() -> Map[String, String] {
-  let headers : Map[String, String] = Map([])
+fn settle_request_headers() -> @async_http.Headers {
+  let headers : @async_http.Headers = Map([])
   headers["User-Agent"] = "MoonBit"
   headers
 }
@@ -249,7 +249,7 @@ fn RequestResult::settle(
 async fn execute_request(
   extension : @cmd.Extension,
   origin : String,
-  headers : Map[String, String],
+  headers : @async_http.Headers,
 ) -> RequestResult {
   async fn run(
     expect : Expecting,

--- a/rabbita/incremental.mbt
+++ b/rabbita/incremental.mbt
@@ -680,6 +680,15 @@ pub impl[T : Eq] Eq for Status[T] with fn equal(a, b) {
 }
 
 ///|
+pub impl[T] Enumerate for Status[T] with fn tag(self) {
+  match self {
+    Pending => "pending"
+    Loaded(_) => "loaded"
+    Failed(_) => "failed"
+  }
+}
+
+///|
 /// An incremental asynchronous resource state.
 pub type Resource[T] = Val[Status[T]]
 

--- a/rabbita/internal/runtime/host_ssr.mbt
+++ b/rabbita/internal/runtime/host_ssr.mbt
@@ -53,26 +53,20 @@ pub async fn SSRHost::SSRHost(
     }
     (host, ambient_host.protect(host, builder))
   })
-  try {
-    let cmd = Context::inject_url_changed(host, host.origin + host.path)
-    Scheduler::queue_command(host, cmd)
+  let cmd = Context::inject_url_changed(host, host.origin + host.path)
+  Scheduler::queue_command(host, cmd)
 
-    let vnode = for ;; {
-      host.drain_task()
-      let tmp = ambient_host.protect(host, () => output.read())
-      if host.task_queue.is_empty() {
-        break tmp
-      }
-    }
-
-    host.document = Some(@vdom.VDom::initialize(vnode, host))
-    host
-  } catch {
-    error => {
-      host.cleanup()
-      raise error
+  let vnode = for ;; {
+    host.drain_task()
+    let tmp = ambient_host.protect(host, () => output.read())
+    if host.task_queue.is_empty() {
+      break tmp
     }
   }
+
+  host.document = Some(@vdom.VDom::initialize(vnode, host))
+  errdefer host.cleanup()
+  host
 }
 
 ///|

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -19,5 +19,5 @@ supported_targets = "js+native+wasm"
 import {
   "moonbitlang/async@0.21.0",
   "hackwaly/moonback@0.8.1",
-  "moonbitlang/x@0.5.0",
+  "moonbitlang/x@0.5.1",
 }

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/rabbita"
 
-version = "0.15.2"
+version = "0.15.3"
 
 readme = "README.md"
 

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -17,5 +17,7 @@ preferred_target = "js"
 supported_targets = "js+native+wasm"
 
 import {
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
+  "hackwaly/moonback@0.8.1",
+  "moonbitlang/x@0.5.0",
 }

--- a/rabbita/pkg.generated.mbti
+++ b/rabbita/pkg.generated.mbti
@@ -65,6 +65,7 @@ pub enum Status[T] {
   Loaded(T)
   Failed(Error)
 }
+pub impl[T] @common.Enumerate for Status[T]
 pub impl[T : Eq] Eq for Status[T]
 
 type Val[A]

--- a/rabbita/server/moon.pkg
+++ b/rabbita/server/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita",
+  "hackwaly/moonback/middlewares/unstable_static" @static,
+  "moonbitlang/async/fs",
+  "moonbitlang/core/env",
+  "moonbitlang/core/string",
+  "moonbitlang/x/path",
+  "hackwaly/moonback",
+}
+
+supported_targets = "native+wasm"

--- a/rabbita/server/server.mbt
+++ b/rabbita/server/server.mbt
@@ -1,0 +1,163 @@
+///|
+using @html {nothing, script, link}
+
+///|
+using @rabbita {type Val, type Html}
+
+///|
+priv enum RunningMode {
+  Prod
+  Dev
+}
+
+///|
+struct Server {
+  app : @moonback.App
+}
+
+///|
+pub fn Server::close(self : Self) -> Unit {
+  self.app.close()
+}
+
+///|
+#internal(experimental, "This API is unstable and may change in the future.")
+pub async fn Server::Server(
+  api~ : @moonback.Module,
+  port~ : UInt16,
+  dist? : @path.Path,
+  component? : () -> Val[Html],
+  silent? : Bool = false,
+) -> Self {
+  // invariants
+  // WARREN_MODE: set `DEV` when `warren dev` running
+  // WARREN_PORT: port in develop
+  // WARREN_CLIENT: dev client src
+  // WARREN_DIST: dev dist path
+  let {
+    "WARREN_CLIENT"? : warren_client,
+    "WARREN_DIST"? : warren_dist,
+    "WARREN_MODE"? : warren_mode,
+    "WARREN_PORT"? : warren_port,
+    ..
+  } = @env.get_env_vars()
+  let mode = match warren_mode {
+    Some("DEV") => Dev
+    _ => Prod
+  }
+  let dist = match mode {
+    Dev => warren_dist
+    Prod => dist.map(Show::to_string)
+  }
+  let port = match mode {
+    Dev => {
+      let s = warren_port.unwrap_or_error(Failure("env WARREN_PORT not found"))
+      @string.parse_uint(s).to_uint16()
+    }
+    Prod => port
+  }
+  let dist = match dist {
+    Some(p) if mode is Prod => Some(p.to_string())
+    _ => @env.get_env_var("WARREN_DIST")
+  }
+  let app = @moonback.App(ctx => {
+    ctx.use_(page_service(port~, warren_client?, dist?, component?))
+    api(ctx)
+  })
+  let listener = @moonback.listen(reuse_addr=true, port~)
+  if !silent {
+    println("Server is running on http://127.0.0.1:\{port}")
+  }
+  app.serve(listener)
+  { app, }
+}
+
+///|
+fn page_service(
+  component? : () -> Val[Html],
+  dist? : String,
+  port~ : UInt16,
+  warren_client? : String,
+) -> @moonback.Module {
+  let head = [
+    link(rel="stylesheet", href="/styles.css"),
+    script(src="/index.js", type_="module", nothing),
+    ..if warren_client is Some(src) && src != "" {
+      Some(@html.script(src~, defer_=true, @html.nothing))
+    },
+  ]
+
+  ctx => {
+    if dist is Some(dir) {
+      ctx.add_middleware(@static.new(root=dir.to_string()))
+    }
+    if component is Some(component) {
+      ctx.get("/", (req, res) => {
+        let host = req.headers.get("Host").unwrap_or("127.0.0.1:\{port}")
+        let url = if req.search is Some(search) {
+          "http://\{host}\{req.path}?\{search}"
+        } else {
+          "http://\{host}\{req.path}"
+        }
+        let page = @rabbita.new(component).render(url~, head~)
+        res.send_html(@moonback.Html::raw(page))
+      })
+    } else {
+      ctx.get("/", (_req, res) => serve_index_html(res, dist?, warren_client?))
+    }
+  }
+}
+
+///|
+async fn serve_index_html(
+  res : @moonback.Responder,
+  dist? : String,
+  warren_client? : String,
+) -> Unit {
+  fn escape_html_attribute(value : String) -> String {
+    value
+    .replace_all(old="&", new="&amp;")
+    .replace_all(old="\"", new="&quot;")
+    .replace_all(old="'", new="&#39;")
+    .replace_all(old="<", new="&lt;")
+    .replace_all(old=">", new="&gt;")
+  }
+
+  fn inject_warren_client(html : String) -> String {
+    guard warren_client is Some(client) && client != "" else { html }
+    let client = escape_html_attribute(client)
+    let double_quoted_src = "src=\"\{client}\""
+    let single_quoted_src = "src='\{client}'"
+    guard !html.contains(double_quoted_src) && !html.contains(single_quoted_src) else {
+      html
+    }
+    let patch = "    <script src=\"\{client}\" defer></script>\n"
+    if html.rev_find("</head>") is Some(index) {
+      "\{html[:index]}\{patch}\{html[index:]}"
+    } else if html.rev_find("</body>") is Some(index) {
+      "\{html[:index]}\{patch}\{html[index:]}"
+    } else if html.rev_find("</html>") is Some(index) {
+      "\{html[:index]}\{patch}\{html[index:]}"
+    } else if html.has_suffix("\n") {
+      "\{html}\{patch}"
+    } else {
+      "\{html}\n\{patch}"
+    }
+  }
+
+  guard dist is Some(dir) else {
+    res.send_text(
+      "index.html not found: no dist directory is configured",
+      status=404,
+    )
+    return
+  }
+  let index_path = @path.Path(dir).join("index.html")
+  let index_path = "\{index_path}"
+  guard @fs.exists(index_path) else {
+    res.send_text("index.html not found: \{index_path}", status=404)
+    return
+  }
+  let html = @fs.read_file(index_path).text()
+  res.send_html(@moonback.Html::raw(inject_warren_client(html)))
+}

--- a/rabbita/top.mbt
+++ b/rabbita/top.mbt
@@ -98,13 +98,8 @@ pub async fn App::render(
   })
   let html = @async.with_timeout(timeout, () => {
     host.render_to_string(head.map(html => html.to_virtual_dom()))
-  }) catch {
-    error => {
-      host.cleanup()
-      raise error
-    }
-  }
-  host.cleanup()
+  })
+  defer host.cleanup()
   html
 }
 

--- a/warren/README.md
+++ b/warren/README.md
@@ -1,113 +1,110 @@
 # warren
 
-`warren` helps you preview and build MoonBit web applications.
-
-Use it during development for a local browser preview with live reload, and use it before publishing to create a static output directory.
+`warren` previews and builds browser-only or full-stack MoonBit applications.
 
 ## Install
-
-Install with Moon:
 
 ```sh
 moon install moonbit-community/warren
 ```
 
-This gives you the `warren` command.
+## Project entries
 
-## New Project
+Warren uses package directories as entries and does not inspect `moon.mod`,
+`moon.pkg`, or `moon.work` contents:
 
-Create a Rabbita app:
+- `cmd/browser` is the default browser entry and is always built for `js`.
+- `cmd/server` is the optional server entry and is built for `wasm` by default,
+  or `native` with `--server-target native`.
+
+Override either convention when needed:
+
+```sh
+warren dev --browser-entry frontend --server-entry backend
+warren build --browser-entry frontend --server-entry backend
+```
+
+The browser entry is required. If no server entry exists, `warren dev` starts
+the built-in development server with its diagnostics, live reload, and optional
+`--direct` mode. If a server entry exists, Warren starts that program instead,
+sets `WARREN_DIST` to the absolute static directory and `WARREN_PORT` to the
+selected port, and leaves HTTP/static serving to the program. `--direct` is not
+available with a custom server. Warren also sets `WARREN_CLIENT` to an
+external reload script served by its development hub. Rabbita SSR applications
+can inject this script through `moonbit-community/rabbita/server/plugin`,
+without depending on a particular HTTP server library. `WARREN_MODE` is set to
+`DEV`.
+Successful browser rebuilds replace the assets in `WARREN_DIST` and reload
+connected pages without modifying `index.js` or restarting an unchanged server.
+
+Use `-C` (or `--directory`) with every subcommand to choose the project root:
+
+```sh
+warren -C path/to/project dev
+warren build -C path/to/project
+warren -C path/to/parent new my-app
+```
+
+Entry, public, and output paths must stay inside that project root. Build output
+must be a safe child directory and cannot overlap an entry or the public
+directory. The minimized template's root browser entry is the one exception:
+its `dist/` child is safe because Warren deletes only that child.
+
+## Development
+
+```sh
+warren dev
+warren dev --public-dir shared/public --port 4301
+warren dev --server-target native
+```
+
+`public/` is used automatically when it exists. Warren watches the whole
+project root and ignores `.git`, `_build`, `.mooncakes`, every directory named
+`dist`, and its own temporary build directory.
+
+Browser-only build failures are reported in the development UI while the last
+successful static output remains available. In full-stack mode, a build failure
+stops the server and exits Warren. A native server is restarted only when its
+artifact changes or the previous process has exited.
+
+## Release build
+
+```sh
+warren build
+warren build --public-dir shared/public --dist output
+warren build --server-target native
+```
+
+The default output directory is `dist/`. Warren clears it at the start, copies
+public files, writes the browser artifact as `index.js`, creates or updates
+`index.html`, and copies an optional server artifact under its original
+basename. Browser and server builds run serially in release mode, reuse Moon's
+default build cache, and locate artifacts only from the `--build-only` JSON
+result without inspecting `_build`. After a wasm server build, Warren prints the
+command for starting the copied artifact, for example:
+
+```sh
+cd /absolute/path/to/dist && moon run server.wasm
+```
+
+## New project
+
+The bundled templates predate the `cmd/browser` convention, so their entry is
+explicit:
 
 ```sh
 warren new my-app
 cd my-app
-warren dev
+warren dev --browser-entry main
 ```
 
-Choose the smaller bundled template when needed:
+For the minimized root-package template:
 
 ```sh
-warren new my-app --template minimized
+warren new tiny-app --template minimized
+cd tiny-app
+warren dev --browser-entry .
 ```
-
-## Development Preview
-
-Run inside your app directory:
-
-```sh
-warren dev
-```
-
-Then open the printed local URL in your browser.
-
-By default, `warren dev` uses:
-
-- `./main` as the main package directory when it exists
-- the current directory otherwise
-- `./public` for static files when it exists
-- port `4300`
-
-You can also choose the main package, static files directory, or port:
-
-```sh
-warren dev path/to/main --public-dir path/to/public --port 4301
-```
-
-To serve the application directly as the top-level page instead, use:
-
-```sh
-warren dev --direct
-```
-
-Direct mode keeps live reload but does not load the Warren development UI. It is useful for applications that depend on top-level navigation, browser APIs, or end-to-end tests without an iframe.
-
-If the port is already used by a previous `warren` preview, `warren` will stop it and continue. If another program is using the port, stop that program manually or choose a different port.
-
-## Release Build
-
-```sh
-warren build
-```
-
-By default, `warren build` builds:
-
-- `./main` when it exists
-- the current directory otherwise
-
-You can also pass the main package directory explicitly:
-
-```sh
-warren build path/to/main
-```
-
-The build output is written to `./dist` by default. You can choose another output path:
-
-```sh
-warren build --dist path/to/dist
-warren build path/to/main --dist path/to/dist
-```
-
-If `public/` exists next to the app directory, its contents are copied into the output directory.
-
-`warren build` tries to compress the generated JavaScript with `terser`.
-If `terser` is not available, it falls back to the uncompressed release JS.
-
-## `public/` Directory
-
-`public/` is optional.
-
-If you want to customize the page, create `public/` next to your app's main package and add:
-
-- `public/index.html`
-- `public/styles.css`
-
-Common usage:
-
-- Add `public/index.html` if you want to control the page structure
-- Add `public/styles.css` if you want custom styles
-- Both files are optional
-
-When `public/index.html` is present, `warren` keeps your page and adds the app entry script when needed. When it is not present, `warren` creates a default page.
 
 ## Help
 

--- a/warren/build.mbt
+++ b/warren/build.mbt
@@ -1,6 +1,14 @@
 ///|
+using @path {type SourcePath, type Path}
+
+///|
 let build_entry_script =
-  #|    <script src="./index.js" type="module"></script>
+  #|    <script src="/index.js" type="module"></script>
+
+///|
+priv struct MoonBuildOutput {
+  artifacts_path : Array[String]
+} derive(FromJson)
 
 ///|
 fn source_path_to_string(path : SourcePath) -> String {
@@ -9,13 +17,25 @@ fn source_path_to_string(path : SourcePath) -> String {
 
 ///|
 fn has_build_entry_script(html : String) -> Bool {
-  html.contains("src=\"./index.js\"") ||
-  html.contains("src='./index.js'") ||
-  html.contains("./index.js")
+  html.contains("src=\"/index.js") || html.contains("src='/index.js")
+}
+
+///|
+fn normalize_build_entry_script(html : String) -> String {
+  html
+  .split("src=\"./index.js\"")
+  .join("src=\"/index.js\"")
+  .split("src='./index.js'")
+  .join("src='/index.js'")
+  .split("src=\"index.js\"")
+  .join("src=\"/index.js\"")
+  .split("src='index.js'")
+  .join("src='/index.js'")
 }
 
 ///|
 fn inject_build_entry_script(html : String) -> String {
+  let html = normalize_build_entry_script(html)
   guard !has_build_entry_script(html) else { html }
   let patch = build_entry_script + "\n"
   match html.rev_find("</head>") {
@@ -42,7 +62,7 @@ fn inject_build_entry_script(html : String) -> String {
 fn default_build_html(has_stylesheet : Bool) -> String {
   let stylesheet = if has_stylesheet {
     (
-      #|    <link rel="stylesheet" type="text/css" href="./styles.css"></link>
+      #|    <link rel="stylesheet" type="text/css" href="/styles.css"></link>
     )
   } else {
     ""
@@ -66,20 +86,16 @@ fn default_build_html(has_stylesheet : Bool) -> String {
 
 ///|
 async fn ensure_clean_dir(path : SourcePath) -> Unit {
-  let path_str = source_path_to_string(path)
-  if @fs.exists(path_str) {
-    match @fs.kind(path_str) {
-      Directory => @fs.rmdir(path_str, recursive=true)
-      _ => @fs.remove(path_str)
+  let path_string = source_path_to_string(path)
+  if @fs.exists(path_string) {
+    match @fs.kind(path_string, follow_symlink=false) {
+      SymLink =>
+        fail("Refusing to replace symbolic-link directory: `\{path_string}`")
+      Directory => @fs.rmdir(path_string, recursive=true)
+      _ => @fs.remove(path_string)
     }
   }
-  @fs.mkdir(path_str, permission=0o755, recursive=true) catch {
-    err => {
-      guard @fs.exists(path_str) && @fs.kind(path_str) is Directory else {
-        raise err
-      }
-    }
-  }
+  @fs.mkdir(path_string, permission=0o755, recursive=true)
 }
 
 ///|
@@ -90,27 +106,92 @@ async fn copy_dir_contents(src : SourcePath, dst : SourcePath) -> Unit {
 }
 
 ///|
-async fn run_release_build(
-  main_pkg_dir : SourcePath,
-  target_dir : SourcePath,
-) -> Unit {
-  let args = [
-    "build",
-    source_path_to_string(main_pkg_dir),
-    "--target",
-    "js",
-    "--release",
-    "--target-dir",
-    source_path_to_string(target_dir),
-  ]
-  let command = args.join(" ")
-  log("build", "Running `moon \{command}`")
-  let exit_code = @process.run("moon", args) catch {
-    err => abort("Failed to run `moon build`: \{err}")
+fn moon_entry(project_root : SourcePath, entry : SourcePath) -> String {
+  match entry.relative(project_root) {
+    "" | "." => "."
+    relative => relative
   }
-  guard exit_code == 0 else {
-    abort("`moon \{command}` exited with code \{exit_code}")
+}
+
+///|
+fn build_only_args(
+  project_root : SourcePath,
+  entry : SourcePath,
+  target : String,
+  release : Bool,
+) -> Array[String] {
+  let args = ["run", "--build-only", "--target", target]
+  if release {
+    args.push("--release")
   }
+  args.push(moon_entry(project_root, entry))
+  args
+}
+
+///|
+fn parse_build_only_artifact(output : String) -> String raise {
+  let result : MoonBuildOutput = @json.from_json(@json.parse(output)) catch {
+    _ =>
+      fail(
+        "`moon run --build-only` returned invalid JSON. Upgrade MoonBit to a version that prints `artifacts_path`.",
+      )
+  }
+  match result.artifacts_path {
+    [artifact] => artifact
+    [] =>
+      fail(
+        "`moon run --build-only` returned no artifact. Upgrade MoonBit if this command does not support `artifacts_path`.",
+      )
+    artifacts =>
+      fail(
+        "`moon run --build-only` returned multiple artifacts: \{Repr(artifacts)}.",
+      )
+  }
+}
+
+///|
+async fn run_build_only(
+  project_root : SourcePath,
+  entry : SourcePath,
+  target : String,
+  release : Bool,
+) -> SourcePath {
+  let args = build_only_args(project_root, entry, target, release)
+  log("build", "Running `moon \{args.join(" ")}`")
+  let (code, stdout, stderr) = @process.collect_output(
+    "moon",
+    args,
+    cwd=source_path_to_string(project_root),
+    inherit_env=true,
+  )
+  let stderr_text = stderr.text().trim().to_owned()
+  let stdout_text = stdout.text().trim().to_owned()
+  if stderr_text != "" {
+    log("moon", stderr_text)
+  }
+  guard code == 0 else {
+    let output = if stderr_text == "" {
+      stdout_text
+    } else if stdout_text == "" {
+      stderr_text
+    } else {
+      "\{stderr_text}\n\{stdout_text}"
+    }
+    let diagnostics = if output == "" {
+      "moon run --build-only exited with code \{code}."
+    } else {
+      "\{output}\n\nmoon run --build-only exited with code \{code}."
+    }
+    fail(diagnostics)
+  }
+  let artifact = parse_build_only_artifact(stdout_text)
+  guard Path::is_absolute(artifact) else {
+    fail("Moon returned a non-absolute artifact path: `\{artifact}`")
+  }
+  guard @fs.exists(artifact) && @fs.kind(artifact) is Regular else {
+    fail("Moon artifact does not exist or is not a file: `\{artifact}`")
+  }
+  SourcePath::new(artifact)
 }
 
 ///|
@@ -149,13 +230,49 @@ async fn run_minifier(
 }
 
 ///|
+async fn minify_or_copy_js(
+  src : SourcePath,
+  dst : SourcePath,
+  project_root : SourcePath,
+) -> Unit {
+  let src_string = source_path_to_string(src)
+  let dst_string = source_path_to_string(dst)
+  let terser_args = [
+    src_string, "-c", "toplevel=true", "-m", "toplevel=true", "-o", dst_string,
+  ]
+  if has_command("terser") {
+    guard !run_minifier("terser", terser_args, project_root, "terser") else {
+      return
+    }
+    copy(src~, dst~)
+    return
+  }
+  if has_command("node") && has_command("npm") {
+    guard !run_minifier(
+      "npm",
+      ["exec", "--yes", "terser", "--", ..terser_args],
+      project_root,
+      "npm exec terser",
+    ) else {
+      return
+    }
+    copy(src~, dst~)
+    return
+  }
+  log(
+    "warn", "terser not found and node/npm unavailable. Using Moon release JS without extra minification.",
+  )
+  copy(src~, dst~)
+}
+
+///|
 async fn write_index_html(dist_dir : SourcePath) -> Unit {
   let index_path = dist_dir.join("index.html")
-  let index_str = source_path_to_string(index_path)
-  if @fs.exists(index_str) {
-    let html = @fs.read_file(index_str).text()
+  let index_string = source_path_to_string(index_path)
+  if @fs.exists(index_string) {
+    let html = @fs.read_file(index_string).text()
     @fs.write_file(
-      index_str,
+      index_string,
       inject_build_entry_script(html),
       create_mode=CreateOrTruncate,
       permission=0o644,
@@ -165,7 +282,7 @@ async fn write_index_html(dist_dir : SourcePath) -> Unit {
       source_path_to_string(dist_dir.join("styles.css")),
     )
     @fs.write_file(
-      index_str,
+      index_string,
       default_build_html(has_stylesheet),
       create_mode=CreateOrTruncate,
       permission=0o644,
@@ -174,86 +291,125 @@ async fn write_index_html(dist_dir : SourcePath) -> Unit {
 }
 
 ///|
-async fn minify_or_copy_js(
-  src : SourcePath,
-  dst : SourcePath,
-  mod_root : SourcePath,
+async fn assemble_static(
+  project_root : SourcePath,
+  public_dir : SourcePath?,
+  browser_artifact : SourcePath,
+  destination : SourcePath,
+  release : Bool,
 ) -> Unit {
-  let src_str = source_path_to_string(src)
-  let dst_str = source_path_to_string(dst)
-  let terser_args = [
-    src_str, "-c", "toplevel=true", "-m", "toplevel=true", "-o", dst_str,
-  ]
-
-  if has_command("terser") {
-    guard !run_minifier("terser", terser_args, mod_root, "terser") else {
-      return
+  if public_dir is Some(dir) {
+    let generated_files = ["index.js"]
+    if !release {
+      generated_files.push("index.js.map")
     }
-    copy(src~, dst~)
-    return
-  }
-
-  if has_command("node") && has_command("npm") {
-    guard !run_minifier(
-      "npm",
-      ["exec", "--yes", "terser", "--", ..terser_args],
-      mod_root,
-      "npm exec terser",
-    ) else {
-      return
+    for generated in generated_files {
+      if @fs.exists(source_path_to_string(dir.join(generated))) {
+        fail("Public files collide with generated `\{generated}`.")
+      }
     }
-    copy(src~, dst~)
-    return
   }
-
-  log(
-    "warn", "terser not found and node/npm unavailable. Using Moon release JS without extra minification.",
-  )
-  copy(src~, dst~)
+  ensure_clean_dir(destination)
+  if public_dir is Some(dir) {
+    copy_dir_contents(dir, destination)
+  }
+  if release {
+    minify_or_copy_js(
+      browser_artifact,
+      destination.join("index.js"),
+      project_root,
+    )
+  } else {
+    let artifact_string = source_path_to_string(browser_artifact)
+    let artifact_basename = Path::basename(artifact_string).to_owned()
+    let map_path = Path::join(
+      Path::dirname(artifact_string),
+      "\{artifact_basename}.map",
+    ).to_string()
+    let browser_js = @fs.read_file(artifact_string)
+      .text()
+      .split("sourceMappingURL=\{artifact_basename}.map")
+      .join("sourceMappingURL=index.js.map")
+    @fs.write_file(
+      source_path_to_string(destination.join("index.js")),
+      browser_js,
+      create_mode=CreateOrTruncate,
+      permission=0o644,
+    )
+    if @fs.exists(map_path) {
+      copy(src=SourcePath::new(map_path), dst=destination.join("index.js.map"))
+    }
+  }
+  write_index_html(destination)
 }
 
 ///|
-pub async fn build_project(
-  main_pkg_dir : SourcePath,
-  dist_dir? : SourcePath,
-) -> Unit {
-  let main_pkg_dir_str = source_path_to_string(main_pkg_dir)
-  let mod_root = if Path::basename(main_pkg_dir_str) == "main" {
-    SourcePath::new(Path::dirname(main_pkg_dir_str).to_string())
+async fn copy_server_artifact(
+  artifact : SourcePath,
+  destination : SourcePath,
+  target : ServerTarget,
+) -> SourcePath {
+  let basename = Path::basename(source_path_to_string(artifact)).to_owned()
+  let output = destination.join(basename)
+  guard !@fs.exists(source_path_to_string(output)) else {
+    fail(
+      "Server artifact `\{basename}` collides with a public or generated file.",
+    )
+  }
+  copy(src=artifact, dst=output)
+  if target is Native {
+    @fs.chmod(source_path_to_string(output), 0o755)
+  }
+  output
+}
+
+///|
+fn server_run_command(
+  dist : SourcePath,
+  target : ServerTarget,
+  server_output : SourcePath?,
+) -> String? {
+  if target is Wasm && server_output is Some(output) {
+    let basename = Path::basename(source_path_to_string(output))
+    Some("cd \{dist} && moon run \{basename}")
   } else {
-    main_pkg_dir
+    None
   }
-  let target_dir = SourcePath::new(@fs.tmpdir(prefix="warren"))
-  let dist_dir = dist_dir.unwrap_or(mod_root.join("dist"))
-  let public_dir = mod_root.join("public")
+}
 
-  run_release_build(main_pkg_dir, target_dir)
-  let build_dir = Path::join(
-    source_path_to_string(target_dir),
-    "js/release/build",
-  ).to_string()
-  let js_paths = find_js_in(build_dir)
-  let release_js = match js_paths {
-    [js_path] => SourcePath::new(js_path)
-    [] => abort("Release JS artifact not found under \{build_dir}")
-    _ =>
-      abort(
-        "Found multiple release JS artifacts: \{Repr(js_paths)}. Use `warren build path/to/main/package/dir` to choose one entry.",
-      )
+///|
+async fn build_project(
+  layout : ProjectLayout,
+  server_target : ServerTarget,
+  dist : SourcePath,
+) -> Unit {
+  ensure_clean_dir(dist)
+  let browser_artifact = run_build_only(
+    layout.root,
+    layout.browser_entry,
+    "js",
+    true,
+  )
+  assemble_static(layout.root, layout.public_dir, browser_artifact, dist, true)
+  let server_output = if layout.server_entry is Some(server_entry) {
+    let server_artifact = run_build_only(
+      layout.root,
+      server_entry,
+      server_target.moon_target(),
+      true,
+    )
+    Some(copy_server_artifact(server_artifact, dist, server_target))
+  } else {
+    None
   }
-
-  ensure_clean_dir(dist_dir)
-  if @fs.exists(source_path_to_string(public_dir)) {
-    guard @fs.kind(source_path_to_string(public_dir)) is Directory else {
-      abort("`public` exists but is not a directory: \{public_dir}")
-    }
-    copy_dir_contents(public_dir, dist_dir)
+  log("build", "Build output written to \{dist}")
+  if server_run_command(dist, server_target, server_output) is Some(command) {
+    println("")
+    log("hint", "Start the server with:")
+    println("")
+    println("  \{command}")
+    println("")
   }
-
-  minify_or_copy_js(release_js, dist_dir.join("index.js"), mod_root)
-  write_index_html(dist_dir)
-
-  log("build", "Build output written to \{dist_dir}")
 }
 
 ///|
@@ -269,7 +425,7 @@ async test "inject_build_entry_script inserts before head" {
     content=(
       $|<html>
       $|<head>
-      $|    <script src="./index.js" type="module"></script>
+      $|    <script src="/index.js" type="module"></script>
       $|</head>
       $|<body></body>
       $|</html>
@@ -278,18 +434,70 @@ async test "inject_build_entry_script inserts before head" {
 }
 
 ///|
-async test "inject_build_entry_script does not duplicate existing entry" {
-  let html =
-    $|<html>
-    $|<body>
-    $|    <script src="./index.js" type="module"></script>
-    $|</body>
-    $|</html>
-  inspect(inject_build_entry_script(html), content=html)
+test "build-only JSON requires exactly one artifact" {
+  inspect(
+    parse_build_only_artifact("{\"artifacts_path\":[\"/tmp/server.exe\"]}"),
+    content="/tmp/server.exe",
+  )
+  let no_artifact = try
+    parse_build_only_artifact("{\"artifacts_path\":[]}")
+  catch {
+    Failure(_) => true
+    _ => false
+  } noraise {
+    _ => false
+  }
+  inspect(no_artifact, content="true")
+  let multiple = try
+    parse_build_only_artifact(
+      "{\"artifacts_path\":[\"/tmp/one\",\"/tmp/two\"]}",
+    )
+  catch {
+    Failure(_) => true
+    _ => false
+  } noraise {
+    _ => false
+  }
+  inspect(multiple, content="true")
+  let invalid = try parse_build_only_artifact("not-json") catch {
+    Failure(_) => true
+    _ => false
+  } noraise {
+    _ => false
+  }
+  inspect(invalid, content="true")
 }
 
 ///|
-async test "default_build_html optionally links stylesheet" {
-  inspect(default_build_html(true).contains("./styles.css"), content="true")
-  inspect(default_build_html(false).contains("./styles.css"), content="false")
+test "build HTML normalizes a relative browser entry" {
+  inspect(
+    inject_build_entry_script(
+      "<html><head><script src=\"./index.js\"></script></head></html>",
+    ),
+    content="<html><head><script src=\"/index.js\"></script></head></html>",
+  )
+}
+
+///|
+test "build-only command reuses Moon's default build cache" {
+  let root = SourcePath::new("test-project")
+  let args = build_only_args(root, root.join("cmd/browser"), "js", false)
+  inspect(args.length(), content="5")
+  inspect(args[0], content="run")
+  inspect(args[1], content="--build-only")
+  inspect(args[3], content="js")
+  inspect(args.contains("--target-dir"), content="false")
+  inspect(args[4] == "cmd/browser" || args[4] == "cmd\\browser", content="true")
+}
+
+///|
+test "wasm build prints the copied server artifact run command" {
+  let dist = SourcePath::new("/workspace/dist")
+  let server = dist.join("server.wasm")
+  assert_eq(
+    server_run_command(dist, Wasm, Some(server)),
+    Some("cd /workspace/dist && moon run server.wasm"),
+  )
+  assert_eq(server_run_command(dist, Native, Some(server)), None)
+  assert_eq(server_run_command(dist, Wasm, None), None)
 }

--- a/warren/config.mbt
+++ b/warren/config.mbt
@@ -1,0 +1,336 @@
+///|
+enum ServerTarget {
+  Native
+  Wasm
+}
+
+///|
+fn ServerTarget::moon_target(self : ServerTarget) -> String {
+  match self {
+    Native => "native"
+    Wasm => "wasm"
+  }
+}
+
+///|
+struct ProjectLayout {
+  root : SourcePath
+  browser_entry : SourcePath
+  server_entry : SourcePath?
+  public_dir : SourcePath?
+}
+
+///|
+fn resolve_from(root : String, raw : String) -> String {
+  if Path::is_absolute(raw) {
+    Path::normalize(raw).to_string()
+  } else {
+    Path::join(root, raw).normalize().to_string()
+  }
+}
+
+///|
+fn relative_is_inside(relative : String, allow_equal : Bool) -> Bool {
+  if relative == "" || relative == "." {
+    return allow_equal
+  }
+  !Path::is_absolute(relative) &&
+  relative != ".." &&
+  !relative.has_prefix("../") &&
+  !relative.has_prefix("..\\")
+}
+
+///|
+fn path_is_inside(child : String, parent : String, allow_equal~ : Bool) -> Bool {
+  relative_is_inside(
+    Path::relative(child, base=parent).to_string(),
+    allow_equal,
+  )
+}
+
+///|
+async fn effective_root(raw : String?) -> SourcePath {
+  let cwd = match @env.current_dir() {
+    Some(path) => path
+    None => fail("Unable to determine the current directory.")
+  }
+  let candidate = resolve_from(cwd, raw.unwrap_or("."))
+  guard @fs.exists(candidate) else {
+    fail("Project directory does not exist: `\{candidate}`")
+  }
+  guard @fs.kind(candidate) is Directory else {
+    fail("Project path is not a directory: `\{candidate}`")
+  }
+  SourcePath::new(@fs.realpath(candidate))
+}
+
+///|
+async fn resolve_input_dir(
+  root : SourcePath,
+  raw : String,
+  label : String,
+) -> SourcePath {
+  let root_string = source_path_to_string(root)
+  let candidate = resolve_from(root_string, raw)
+  guard @fs.exists(candidate) else {
+    fail("\{label} directory does not exist: `\{candidate}`")
+  }
+  let canonical = @fs.realpath(candidate)
+  guard @fs.kind(canonical) is Directory else {
+    fail("\{label} path is not a directory: `\{candidate}`")
+  }
+  guard path_is_inside(canonical, root_string, allow_equal=true) else {
+    fail("\{label} must stay inside -C `\{root_string}`: `\{candidate}`")
+  }
+  SourcePath::new(canonical)
+}
+
+///|
+async fn nearest_existing_parent(path : String) -> (String, String) {
+  for current = path {
+    if @fs.exists(current) {
+      break (current, @fs.realpath(current))
+    }
+    let parent = Path::dirname(current).to_string()
+    if parent == current {
+      break fail("No existing parent directory for `\{path}`.")
+    }
+    continue parent
+  }
+}
+
+///|
+fn rebuild_from_canonical_parent(
+  path : String,
+  lexical_parent : String,
+  canonical_parent : String,
+) -> String {
+  let remainder = Path::relative(path, base=lexical_parent).to_string()
+  if remainder == "" || remainder == "." {
+    canonical_parent
+  } else {
+    Path::join(canonical_parent, remainder).normalize().to_string()
+  }
+}
+
+///|
+fn protected_output_path(relative : String) -> Bool {
+  let normalized = relative.split("\\").join("/")
+  match normalized.split("/").collect() {
+    [first, ..] => first == ".git" || first == "_build" || first == ".mooncakes"
+    [] => false
+  }
+}
+
+///|
+async fn resolve_dist_dir(root : SourcePath, raw : String) -> SourcePath {
+  let root_string = source_path_to_string(root)
+  let candidate = resolve_from(root_string, raw)
+  let relative = Path::relative(candidate, base=root_string).to_string()
+  guard relative_is_inside(relative, false) else {
+    fail("--dist must be a child of -C `\{root_string}`: `\{candidate}`")
+  }
+  guard !protected_output_path(relative) else {
+    fail("Refusing dangerous --dist path: `\{candidate}`")
+  }
+  let resolved_output = if @fs.exists(candidate) {
+    let output_kind = @fs.kind(candidate, follow_symlink=false)
+    guard !(output_kind is SymLink) else {
+      fail("--dist must not be a symbolic link: `\{candidate}`")
+    }
+    guard output_kind is Directory else {
+      fail("--dist exists but is not a directory: `\{candidate}`")
+    }
+    let canonical = @fs.realpath(candidate)
+    guard path_is_inside(canonical, root_string, allow_equal=false) else {
+      fail("--dist resolves outside -C: `\{candidate}`")
+    }
+    canonical
+  } else {
+    let (lexical_parent, canonical_parent) = nearest_existing_parent(candidate)
+    guard @fs.kind(canonical_parent) is Directory else {
+      fail("--dist parent is not a directory: `\{lexical_parent}`")
+    }
+    let canonical = rebuild_from_canonical_parent(
+      candidate, lexical_parent, canonical_parent,
+    )
+    guard path_is_inside(canonical, root_string, allow_equal=false) else {
+      fail("--dist has a parent that resolves outside -C: `\{candidate}`")
+    }
+    canonical
+  }
+  let resolved_relative = Path::relative(resolved_output, base=root_string).to_string()
+  guard !protected_output_path(resolved_relative) else {
+    fail("Refusing dangerous --dist path: `\{candidate}`")
+  }
+  SourcePath::new(resolved_output)
+}
+
+///|
+fn paths_overlap(a : SourcePath, b : SourcePath) -> Bool {
+  let a = source_path_to_string(a)
+  let b = source_path_to_string(b)
+  path_is_inside(a, b, allow_equal=true) ||
+  path_is_inside(b, a, allow_equal=true)
+}
+
+///|
+fn validate_dist_inputs(
+  root : SourcePath,
+  dist : SourcePath,
+  browser_entry : SourcePath,
+  server_entry : SourcePath?,
+  public_dir : SourcePath?,
+) -> Unit raise {
+  if browser_entry != root {
+    guard !paths_overlap(dist, browser_entry) else {
+      fail("--dist must not overlap --browser-entry.")
+    }
+  }
+  if server_entry is Some(entry) {
+    guard !paths_overlap(dist, entry) else {
+      fail("--dist must not overlap --server-entry.")
+    }
+  }
+  if public_dir is Some(dir) {
+    guard !paths_overlap(dist, dir) else {
+      fail("--dist must not overlap --public-dir.")
+    }
+  }
+}
+
+///|
+async fn resolve_project_layout(
+  root : SourcePath,
+  browser_entry_raw : String?,
+  server_entry_raw : String?,
+  public_dir_raw : String?,
+) -> ProjectLayout {
+  let browser_entry = resolve_input_dir(
+    root,
+    browser_entry_raw.unwrap_or("cmd/browser"),
+    "Browser entry",
+  )
+  let server_entry = match server_entry_raw {
+    Some(raw) => Some(resolve_input_dir(root, raw, "Server entry"))
+    None => {
+      let conventional = resolve_from(source_path_to_string(root), "cmd/server")
+      if @fs.exists(conventional) {
+        Some(resolve_input_dir(root, "cmd/server", "Server entry"))
+      } else {
+        None
+      }
+    }
+  }
+  let public_dir = match public_dir_raw {
+    Some(raw) => Some(resolve_input_dir(root, raw, "Public"))
+    None => {
+      let conventional = resolve_from(source_path_to_string(root), "public")
+      if @fs.exists(conventional) {
+        Some(resolve_input_dir(root, "public", "Public"))
+      } else {
+        None
+      }
+    }
+  }
+  { root, browser_entry, server_entry, public_dir }
+}
+
+///|
+fn parse_server_target(raw : String?) -> ServerTarget raise {
+  match raw {
+    None | Some("wasm") => Wasm
+    Some("native") => Native
+    Some(value) =>
+      fail("Invalid --server-target `\{value}`. Expected `native` or `wasm`.")
+  }
+}
+
+///|
+fn parse_port(raw : String?) -> UInt raise {
+  let value = raw.unwrap_or("4300")
+  let parsed = @string.parse_int(value) catch {
+    _ =>
+      fail(
+        "Invalid --port value `\{value}`. Expected a number from 1 to 65535.",
+      )
+  }
+  guard parsed > 0 && parsed <= 65535 else {
+    fail("Invalid --port value `\{value}`. Expected a number from 1 to 65535.")
+  }
+  parsed.reinterpret_as_uint()
+}
+
+///|
+fn ignored_watch_path(path : String) -> Bool {
+  let normalized = path.split("\\").join("/")
+  normalized
+  .split("/")
+  .any(part => {
+    part == ".git" || part == "_build" || part == ".mooncakes" || part == "dist"
+  })
+}
+
+///|
+fn ignored_watch_path_with_temp(path : String, temp_relative : String) -> Bool {
+  if ignored_watch_path(path) {
+    return true
+  }
+  guard relative_is_inside(temp_relative, false) else { return false }
+  let normalized = path.split("\\").join("/")
+  let normalized_temp = temp_relative.split("\\").join("/")
+  normalized == normalized_temp || normalized.has_prefix("\{normalized_temp}/")
+}
+
+///|
+test "relative path containment" {
+  inspect(relative_is_inside("", true), content="true")
+  inspect(relative_is_inside("child/file", false), content="true")
+  inspect(relative_is_inside("../outside", true), content="false")
+  inspect(relative_is_inside("..\\outside", true), content="false")
+}
+
+///|
+test "watch ignores fixed generated directories" {
+  inspect(ignored_watch_path("cmd/browser/main.mbt"), content="false")
+  inspect(ignored_watch_path("cmd/browser/_build/out.js"), content="true")
+  inspect(ignored_watch_path("nested/dist/index.js"), content="true")
+  inspect(ignored_watch_path(".git/index"), content="true")
+  inspect(
+    ignored_watch_path_with_temp(".warren-temp/static/index.js", ".warren-temp"),
+    content="true",
+  )
+}
+
+///|
+test "server target defaults to wasm" {
+  assert_true(parse_server_target(None) is Wasm)
+  assert_true(parse_server_target(Some("wasm")) is Wasm)
+  assert_true(parse_server_target(Some("native")) is Native)
+}
+
+///|
+test "dist may be nested under a root browser entry" {
+  let root = SourcePath::new("test-project")
+  validate_dist_inputs(root, root.join("dist"), root, None, None)
+}
+
+///|
+test "dist may not contain an entry" {
+  let root = SourcePath::new("test-project")
+  let rejected = try
+    validate_dist_inputs(
+      root,
+      root.join("output"),
+      root.join("output/cmd/browser"),
+      None,
+      None,
+    )
+  catch {
+    Failure(_) => true
+    _ => false
+  } noraise {
+    _ => false
+  }
+  inspect(rejected, content="true")
+}

--- a/warren/dev.mbt
+++ b/warren/dev.mbt
@@ -1,0 +1,390 @@
+///|
+using @devhub {type Devhub}
+
+///|
+struct ArtifactDigest {
+  hash : Int
+  length : Int
+} derive(Eq)
+
+///|
+struct RunningServer {
+  process : @process.Process
+  digest : ArtifactDigest
+}
+
+///|
+async fn artifact_digest(path : SourcePath) -> ArtifactDigest {
+  let bytes = @fs.read_file(source_path_to_string(path)).binary()
+  { hash: bytes.hash(), length: bytes.length() }
+}
+
+///|
+fn ArtifactDigest::directory_name(self : ArtifactDigest) -> String {
+  "\{self.hash}-\{self.length}"
+}
+
+///|
+fn server_needs_restart(
+  previous : ArtifactDigest?,
+  previous_running : Bool,
+  next : ArtifactDigest,
+) -> Bool {
+  match previous {
+    None => true
+    Some(previous) => previous != next || !previous_running
+  }
+}
+
+///|
+fn wasm_server_args(
+  project_root : SourcePath,
+  server_entry : SourcePath,
+) -> Array[String] {
+  ["run", "--target", "wasm", moon_entry(project_root, server_entry)]
+}
+
+///|
+fn mount_browser_pages(
+  vfs : @vfs.VirtualFileSystem,
+  app_html : String,
+  direct : Bool,
+) -> Unit {
+  if direct {
+    vfs.mount("/index.html", FileContent(inject_direct_assets(app_html)))
+    vfs.mount("/__warren/direct.js", FileContent(direct_client_js))
+  } else {
+    vfs.mount(
+      "/__warren/preview/index.html",
+      FileContent(inject_preview_assets(app_html)),
+    )
+    vfs.mount("/index.html", FileContent(shell_html_template))
+    vfs.mount("/warren_devtool.js", FileContent(embbed_devtool_js))
+    vfs.mount("/warren_devtool.css", FileContent(embbed_devtool_css))
+  }
+}
+
+///|
+async fn publish_browser_static(
+  vfs : @vfs.VirtualFileSystem,
+  static_dir : SourcePath,
+  direct : Bool,
+) -> Unit {
+  vfs.mount("/", DirectoryMapping(static_dir))
+  let index = static_dir.join("index.html")
+  let app_html = if @fs.exists(source_path_to_string(index)) {
+    @fs.read_file(source_path_to_string(index)).text()
+  } else {
+    app_html_template
+  }
+  mount_browser_pages(vfs, app_html, direct)
+}
+
+///|
+async fn browser_dev(
+  layout : ProjectLayout,
+  temp : SourcePath,
+  port : UInt,
+  direct : Bool,
+) -> Unit {
+  let root = source_path_to_string(layout.root)
+  let temp_relative = temp.relative(layout.root)
+  let watcher = @fs.Watcher(root, ignored_paths=path => {
+    ignored_watch_path_with_temp(path, temp_relative)
+  })
+  defer watcher.close()
+  let vfs = @vfs.new(Map([]))
+  mount_browser_pages(vfs, app_html_template, direct)
+  let mut next_static = temp.join("static")
+  let mut standby_static = temp.join("static-next")
+  @async.with_task_group <| group => {
+    let html_fallback_path = if direct { Some("/index.html") } else { None }
+    let hub = Devhub(port, vfs, html_fallback_path?)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => hub.run_forever())
+    log("info", "Running server on http://127.0.0.1:\{hub.port()}")
+    while true {
+      hub.broadcast(Building)
+      log("warren", "Building browser entry...")
+      try {
+        let browser_artifact = run_build_only(
+          layout.root,
+          layout.browser_entry,
+          "js",
+          false,
+        )
+        assemble_static(
+          layout.root,
+          layout.public_dir,
+          browser_artifact,
+          next_static,
+          false,
+        )
+        publish_browser_static(vfs, next_static, direct)
+      } catch {
+        error if @async.is_being_cancelled() => raise error
+        error => {
+          let diagnostics = match error {
+            Failure(message) => message
+            error => "\{error}"
+          }
+          hub.broadcast(BuildFailed(diagnostics))
+          log("error", diagnostics)
+        }
+      } noraise {
+        _ => {
+          let old_active = next_static
+          next_static = standby_static
+          standby_static = old_active
+          hub.broadcast(Reload)
+          log("warren", "Changes detected. Reloading...")
+        }
+      }
+      watcher.wait_any()
+    }
+  }
+}
+
+///|
+fn process_is_running(process : @process.Process) -> Bool {
+  try process.try_wait() catch {
+    _ => false
+  } noraise {
+    None => true
+    Some(_) => false
+  }
+}
+
+///|
+async fn stop_server(server : RunningServer?) -> Unit {
+  if server is Some(server) {
+    if process_is_running(server.process) {
+      // `Process::cancel()` cancels its monitoring task, so a following
+      // `wait()` raises `Cancelled` even after the child has terminated.
+      // Run the same graceful handler separately and keep waiting for the OS
+      // process; once it exits, this group cancels the pending forced kill.
+      @async.with_task_group <| group => {
+        group.spawn_bg(no_wait=true, () => {
+          @process.graceful_cancel(timeout=5000)(server.process.pid)
+        })
+        ignore(server.process.wait())
+      }
+    } else {
+      ignore(server.process.wait())
+    }
+  }
+}
+
+///|
+async fn stage_native_server(
+  artifact : SourcePath,
+  run_dir : SourcePath,
+  digest : ArtifactDigest,
+) -> SourcePath {
+  let directory = run_dir.join(digest.directory_name())
+  if !@fs.exists(source_path_to_string(directory)) {
+    @fs.mkdir(
+      source_path_to_string(directory),
+      permission=0o755,
+      recursive=true,
+    )
+  }
+  let basename = Path::basename(source_path_to_string(artifact)).to_owned()
+  let executable = directory.join(basename)
+  if !@fs.exists(source_path_to_string(executable)) {
+    copy(src=artifact, dst=executable)
+    @fs.chmod(source_path_to_string(executable), 0o755)
+  }
+  executable
+}
+
+///|
+fn dev_server_environment(
+  static_dir : SourcePath,
+  port : UInt,
+  client : String,
+) -> Map[String, String] {
+  {
+    "WARREN_MODE": "DEV",
+    "WARREN_PORT": "\{port}",
+    "WARREN_CLIENT": client,
+    "WARREN_DIST": source_path_to_string(static_dir),
+  }
+}
+
+///|
+async fn start_server(
+  group : @async.TaskGroup[Unit],
+  layout : ProjectLayout,
+  target : ServerTarget,
+  run_dir : SourcePath,
+  artifact : SourcePath,
+  digest : ArtifactDigest,
+  static_dir : SourcePath,
+  port : UInt,
+  dev_client : String,
+) -> @process.Process {
+  let environment = dev_server_environment(static_dir, port, dev_client)
+  match target {
+    Native => {
+      let executable = stage_native_server(artifact, run_dir, digest)
+      log("server", "Starting \{executable} with WARREN_PORT=\{port}")
+      @process.spawn(
+        group,
+        source_path_to_string(executable),
+        [],
+        cwd=source_path_to_string(layout.root),
+        extra_env=environment,
+        inherit_env=true,
+        cancel_handler=@process.graceful_cancel(timeout=5000),
+        no_wait=true,
+      )
+    }
+    Wasm => {
+      let server_entry = match layout.server_entry {
+        Some(entry) => entry
+        None => fail("Cannot start a wasm server without a server entry.")
+      }
+      let args = wasm_server_args(layout.root, server_entry)
+      log("server", "Running `moon \{args.join(" ")}` with WARREN_PORT=\{port}")
+      @process.spawn(
+        group,
+        "moon",
+        args,
+        cwd=source_path_to_string(layout.root),
+        extra_env=environment,
+        inherit_env=true,
+        cancel_handler=@process.graceful_cancel(timeout=5000),
+        no_wait=true,
+      )
+    }
+  }
+}
+
+///|
+async fn fullstack_dev(
+  layout : ProjectLayout,
+  server_entry : SourcePath,
+  target : ServerTarget,
+  temp : SourcePath,
+  port : UInt,
+) -> Unit {
+  let root = source_path_to_string(layout.root)
+  let static_dir = temp.join("static")
+  let run_dir = temp.join("run")
+  let temp_relative = temp.relative(layout.root)
+  let watcher = @fs.Watcher(root, ignored_paths=path => {
+    ignored_watch_path_with_temp(path, temp_relative)
+  })
+  defer watcher.close()
+  @async.with_task_group <| group => {
+    let hub = Devhub(
+      0U,
+      @vfs.new({ "/__warren/client.js": FileContent(fullstack_client_js) }),
+    )
+    group.spawn_bg(no_wait=true, allow_failure=true, () => hub.run_forever())
+    let events_port = hub.port()
+    let dev_client = "http://127.0.0.1:\{events_port}/__warren/client.js"
+    let mut running : RunningServer? = None
+    while true {
+      hub.broadcast(Building)
+      log("warren", "Building browser entry...")
+      let browser_artifact = run_build_only(
+        layout.root,
+        layout.browser_entry,
+        "js",
+        false,
+      )
+      assemble_static(
+        layout.root,
+        layout.public_dir,
+        browser_artifact,
+        static_dir,
+        false,
+      )
+      log("warren", "Building server entry...")
+      let server_artifact = run_build_only(
+        layout.root,
+        server_entry,
+        target.moon_target(),
+        false,
+      )
+      let digest = artifact_digest(server_artifact)
+      let (previous_digest, previous_running) = match running {
+        None => (None, false)
+        Some(server) =>
+          (Some(server.digest), process_is_running(server.process))
+      }
+      let restart = server_needs_restart(
+        previous_digest, previous_running, digest,
+      )
+      if restart {
+        stop_server(running)
+        let process = start_server(
+          group, layout, target, run_dir, server_artifact, digest, static_dir, port,
+          dev_client,
+        )
+        running = Some({ process, digest })
+      } else {
+        log(
+          "server", "Server artifact is unchanged; keeping the server running.",
+        )
+      }
+      hub.broadcast(Reload)
+      log("warren", "Changes detected. Reloading browser resources...")
+      watcher.wait_any()
+    }
+  }
+}
+
+///|
+async fn dev_project(
+  layout : ProjectLayout,
+  server_target : ServerTarget,
+  port : UInt,
+  direct : Bool,
+) -> Unit {
+  let temp = SourcePath::new(@fs.tmpdir(prefix="warren-dev"))
+  match layout.server_entry {
+    None => browser_dev(layout, temp, port, direct)
+    Some(server_entry) =>
+      fullstack_dev(layout, server_entry, server_target, temp, port)
+  }
+}
+
+///|
+test "server restart depends on digest and process state" {
+  let digest : ArtifactDigest = { hash: 42, length: 10 }
+  inspect(server_needs_restart(None, false, digest), content="true")
+  inspect(server_needs_restart(Some(digest), true, digest), content="false")
+  inspect(server_needs_restart(Some(digest), false, digest), content="true")
+  inspect(
+    server_needs_restart(Some(digest), true, { hash: 43, length: 10 }),
+    content="true",
+  )
+}
+
+///|
+test "fullstack server receives the Warren development environment" {
+  let static_dir = SourcePath::new("static")
+  let client = "http://127.0.0.1:43123/__warren/client.js"
+  let environment = dev_server_environment(static_dir, 4300U, client)
+  assert_eq(environment.length(), 4)
+  assert_eq(environment.get("WARREN_MODE"), Some("DEV"))
+  assert_eq(environment.get("WARREN_PORT"), Some("4300"))
+  assert_eq(environment.get("WARREN_CLIENT"), Some(client))
+  assert_eq(
+    environment.get("WARREN_DIST"),
+    Some(source_path_to_string(static_dir)),
+  )
+}
+
+///|
+test "wasm server is launched through moon run" {
+  let root = SourcePath::new("test-project")
+  let args = wasm_server_args(root, root.join("cmd/server"))
+  inspect(args.length(), content="4")
+  inspect(args[0], content="run")
+  inspect(args[2], content="wasm")
+  inspect(args.contains("--target-dir"), content="false")
+  inspect(args[3] == "cmd/server" || args[3] == "cmd\\server", content="true")
+}

--- a/warren/main.mbt
+++ b/warren/main.mbt
@@ -1,13 +1,4 @@
 ///|
-using @path {type SourcePath, type Path}
-
-///|
-using @devhub {type Devhub}
-
-///|
-using @string {parse_int}
-
-///|
 let shell_html_template =
   $|<!DOCTYPE html>
   $|<html lang="en">
@@ -70,19 +61,57 @@ let direct_client_js =
   #|connect();
 
 ///|
-async fn main {
-  let cli = @argparse.Command(
+let fullstack_client_js =
+  #|(function () {
+  #|  const script = document.currentScript;
+  #|  if (!script) {
+  #|    return;
+  #|  }
+  #|  const clientUrl = new URL(script.src);
+  #|  const protocol = clientUrl.protocol === "https:" ? "wss:" : "ws:";
+  #|  const eventsUrl = `${protocol}//${clientUrl.host}/__warren/events`;
+  #|  function connect() {
+  #|    const socket = new WebSocket(eventsUrl);
+  #|    socket.addEventListener("message", event => {
+  #|      if (event.data === "reload") {
+  #|        location.reload();
+  #|      }
+  #|    });
+  #|    socket.addEventListener("close", () => {
+  #|      setTimeout(connect, 1000);
+  #|    });
+  #|  }
+  #|  connect();
+  #|})();
+
+///|
+fn warren_cli() -> @argparse.Command {
+  Command(
     "warren",
+    options=[
+      OptionArg(
+        "directory",
+        short='C',
+        global=true,
+        about="Run as if Warren was started in this directory.",
+      ),
+    ],
     subcommands=[
       Command(
         "dev",
-        positionals=[
-          PositionArg(
-            "main-package-dir",
-            about="Main package directory. Defaults to ./main when present, otherwise the current directory.",
-          ),
-        ],
         options=[
+          OptionArg(
+            "browser-entry",
+            about="Browser entry package directory. Default: ./cmd/browser.",
+          ),
+          OptionArg(
+            "server-entry",
+            about="Server entry package directory. Default: ./cmd/server when present.",
+          ),
+          OptionArg(
+            "server-target",
+            about="Server target: wasm (default) or native.",
+          ),
           OptionArg(
             "public-dir",
             about="Static files directory. Defaults to ./public when present.",
@@ -99,16 +128,26 @@ async fn main {
       ),
       Command(
         "build",
-        positionals=[
-          PositionArg(
-            "main-package-dir",
-            about="Main package directory to build. Defaults to ./main when present, otherwise the current directory.",
-          ),
-        ],
         options=[
+          OptionArg(
+            "browser-entry",
+            about="Browser entry package directory. Default: ./cmd/browser.",
+          ),
+          OptionArg(
+            "server-entry",
+            about="Server entry package directory. Default: ./cmd/server when present.",
+          ),
+          OptionArg(
+            "server-target",
+            about="Server target: wasm (default) or native.",
+          ),
+          OptionArg(
+            "public-dir",
+            about="Static files directory. Defaults to ./public when present.",
+          ),
           OptionArg("dist", about="Build output directory. Default: ./dist."),
         ],
-        about="Build a release static site into ./dist by default.",
+        about="Build browser and optional server release artifacts.",
       ),
       Command(
         "new",
@@ -127,62 +166,71 @@ async fn main {
         about="Create a minimal Rabbita project.",
       ),
     ],
-    about="Preview and build MoonBit web applications.",
-  ).parse()
-  let cwd = @env.current_dir().unwrap()
+    about="Preview and build full-stack MoonBit applications.",
+  )
+}
+
+///|
+fn option_value(matches : @argparse.Matches, name : String) -> String? {
+  match matches.values.get(name) {
+    Some([value]) => Some(value)
+    _ => None
+  }
+}
+
+///|
+async fn run_cli() -> Unit {
+  let cli = warren_cli().parse()
   guard cli.subcommand is Some((subcmd, submatches)) else { return }
+  let directory = match option_value(submatches, "directory") {
+    Some(path) => Some(path)
+    None => option_value(cli, "directory")
+  }
+  let root = effective_root(directory)
   match subcmd {
     "dev" => {
-      let cwd_main = Path::join(cwd, "main").to_string()
-      let main_pkg_dir = match submatches.values.get("main-package-dir") {
-        Some([path]) => Path::resolve(path).to_string()
-        _ if @fs.exists(cwd_main) => cwd_main
-        _ => cwd
+      let layout = resolve_project_layout(
+        root,
+        option_value(submatches, "browser-entry"),
+        option_value(submatches, "server-entry"),
+        option_value(submatches, "public-dir"),
+      )
+      let target_raw = option_value(submatches, "server-target")
+      let server_target = parse_server_target(target_raw)
+      if target_raw is Some(_) && layout.server_entry is None {
+        fail("--server-target requires a server entry.")
       }
-      let cwd_public = Path::join(cwd, "public").to_string()
-      let public_dir = match submatches.values.get("public-dir") {
-        Some([path]) => Some(Path::resolve(path).to_string())
-        _ if @fs.exists(cwd_public) => Some(cwd_public)
-        _ => None
-      }
-      let port = match submatches.values.get("port") {
-        Some([raw]) => {
-          let port = parse_int(raw) catch {
-            _ =>
-              abort(
-                "Invalid --port value `\{raw}`. Expected a number from 1 to 65535.",
-              )
-          }
-
-          guard port > 0 && port <= 65535 else {
-            abort(
-              "Invalid --port value `\{raw}`. Expected a number from 1 to 65535.",
-            )
-          }
-
-          port.reinterpret_as_uint()
-        }
-        _ => 4300U
-      }
+      let port = parse_port(option_value(submatches, "port"))
       let direct = submatches.flags.get("direct") is Some(true)
-      let target_dir = @fs.tmpdir(prefix="warren")
-      dev_server(main_pkg_dir~, target_dir~, public_dir~, port~, direct~)
+      if direct && layout.server_entry is Some(_) {
+        fail("--direct is only available when no server entry exists.")
+      }
+      dev_project(layout, server_target, port, direct)
     }
     "build" => {
-      let cwd_main = Path::join(cwd, "main").to_string()
-      let main_pkg_dir = match submatches.values.get("main-package-dir") {
-        Some([path]) => Path::resolve(path).to_string()
-        _ if @fs.exists(cwd_main) => cwd_main
-        _ => cwd
-      }
-      let dist_dir = match submatches.values.get("dist") {
-        Some([path]) => Path::resolve(path).to_string()
-        _ => Path::join(cwd, "dist").to_string()
-      }
-      build_project(
-        SourcePath::new(main_pkg_dir),
-        dist_dir=SourcePath::new(dist_dir),
+      let layout = resolve_project_layout(
+        root,
+        option_value(submatches, "browser-entry"),
+        option_value(submatches, "server-entry"),
+        option_value(submatches, "public-dir"),
       )
+      let target_raw = option_value(submatches, "server-target")
+      let server_target = parse_server_target(target_raw)
+      if target_raw is Some(_) && layout.server_entry is None {
+        fail("--server-target requires a server entry.")
+      }
+      let dist = resolve_dist_dir(
+        root,
+        option_value(submatches, "dist").unwrap_or("dist"),
+      )
+      validate_dist_inputs(
+        root,
+        dist,
+        layout.browser_entry,
+        layout.server_entry,
+        layout.public_dir,
+      )
+      build_project(layout, server_target, dist)
     }
     "new" =>
       match submatches.values.get("dir_name") {
@@ -191,12 +239,17 @@ async fn main {
             Some([name]) => name
             _ => default_new_project_template
           }
-          new_project(dir, template)
+          new_project(root, dir, template)
         }
         _ => println("Usage: warren new <dir_name> [--template <template>]")
       }
     _ => ()
   }
+}
+
+///|
+async fn main {
+  run_cli()
 }
 
 ///|
@@ -296,157 +349,35 @@ test "inject_preview_assets puts base before relative assets" {
 }
 
 ///|
-fn build_failure_diagnostics(output : String, code : Int) -> String {
-  let output = output.trim().to_owned()
-  if output == "" {
-    "moon build exited with code \{code}."
-  } else {
-    output + "\n\nmoon build exited with code \{code}."
+test "CLI accepts global -C and full-stack entry options" {
+  let matches = warren_cli().parse(
+    argv=[
+      "-C", "project", "dev", "--browser-entry", "frontend", "--server-entry", "backend",
+      "--server-target", "wasm",
+    ],
+    env={},
+  )
+  assert_eq(option_value(matches, "directory"), Some("project"))
+  let entries = match matches.subcommand {
+    Some(("dev", submatches)) =>
+      (
+        option_value(submatches, "browser-entry"),
+        option_value(submatches, "server-entry"),
+        option_value(submatches, "server-target"),
+      )
+    _ => (None, None, None)
   }
+  assert_eq(entries.0, Some("frontend"))
+  assert_eq(entries.1, Some("backend"))
+  assert_eq(entries.2, Some("wasm"))
 }
 
 ///|
-async fn dev_server(
-  main_pkg_dir~ : String,
-  target_dir~ : String,
-  public_dir~ : String?,
-  port~ : UInt,
-  direct~ : Bool,
-) -> Unit {
-  let watcher = @fs.Watcher(main_pkg_dir, ignored_paths=path => {
-    path.contains(".mooncakes") ||
-    path.contains("node_modules") ||
-    path.contains("_build")
-  })
-
-  let vfs = @vfs.new(Map([]))
-  let app_html = match public_dir {
-    Some(dir) => {
-      vfs.mount("/", DirectoryMapping(SourcePath::new(dir)))
-      let files = @fs.readdir(dir)
-      if files.contains("index.html") {
-        @fs.read_file(Path::join(dir, "index.html").to_string()).text()
-      } else {
-        app_html_template
-      }
-    }
-    None => app_html_template
+test "CLI rejects the removed positional build entry" {
+  let rejected = try warren_cli().parse(argv=["build", "main"], env={}) catch {
+    _ => true
+  } noraise {
+    _ => false
   }
-  if direct {
-    vfs.mount("/index.html", FileContent(inject_direct_assets(app_html)))
-    vfs.mount("/__warren/direct.js", FileContent(direct_client_js))
-  } else {
-    vfs.mount(
-      "/__warren/preview/index.html",
-      FileContent(inject_preview_assets(app_html)),
-    )
-    vfs.mount("/index.html", FileContent(shell_html_template))
-    vfs.mount("/warren_devtool.js", FileContent(embbed_devtool_js))
-    vfs.mount("/warren_devtool.css", FileContent(embbed_devtool_css))
-  }
-
-  @async.with_task_group <| group => {
-    let html_fallback_path = if direct { Some("/index.html") } else { None }
-    let hub = Devhub(port, vfs, html_fallback_path?)
-    group.spawn_bg(no_wait=true, allow_failure=true, () => hub.run_forever())
-    log("info", "Running server on http://127.0.0.1:\{hub.port()}")
-
-    while true {
-      let (reader, out) = @process.read_from_process()
-      let (stdin, close_stdin) = @process.write_to_process()
-      close_stdin.close()
-      @fs.rmdir(target_dir, recursive=true)
-      hub.broadcast(Building)
-      log("warren", "Building...")
-
-      defer reader.close()
-      let diagnostics = StringBuilder::new()
-      let code = @async.with_task_group <| build_group => {
-        let exit_code = build_group.spawn(() => {
-          @process.run(
-            "moon",
-            [
-              "build", main_pkg_dir, "--target", "js", "--target-dir", target_dir,
-            ],
-            stdin~,
-            stdout=out,
-            stderr=out,
-          )
-        })
-
-        while reader.read_until("\n") is Some(line) {
-          if line != "" {
-            diagnostics.write_string(line)
-            diagnostics.write_string("\n")
-            log("moon", line)
-          }
-        }
-        exit_code.wait()
-      }
-
-      if code == 0 {
-        log("warren", "moon build succeed at \{main_pkg_dir}.")
-        let js_paths = find_js_in(
-          Path::join(target_dir, "js/debug/build").to_string(),
-        )
-        guard js_paths is [js_path] else {
-          log("error", "found multiple entries: \{Repr(js_paths)}")
-          log(
-            "info", "Use `warren dev path/to/main/package/dir` to choose one entry.",
-          )
-        }
-
-        let basename = Path::basename(js_path)
-        let js_map_path = Path::dirname(js_path)
-          .join("\{basename}.map")
-          .to_string()
-
-        if @fs.exists(js_map_path) {
-          vfs.mount("index.js.map", FileMapping(SourcePath::new(js_map_path)))
-        } else {
-          vfs.unmount("index.js.map")
-        }
-
-        vfs.mount("index.js", FileMapping(SourcePath::new(js_path)))
-        // debug(vfs)
-        hub.broadcast(Reload)
-        log("warren", "Changes detected. Reloading...")
-      } else {
-        hub.broadcast(
-          BuildFailed(build_failure_diagnostics(diagnostics.to_string(), code)),
-        )
-        log("error", "moon exited with code \{code}.")
-      }
-
-      watcher.wait_any()
-    }
-  }
-}
-
-///|
-async fn find_js_in(dir : String) -> Array[String] {
-  async fn collect_js_in(dir : String, js_paths : Array[String]) -> Unit {
-    guard @fs.kind(dir) is Directory else { return }
-    let handle = @fs.opendir(dir)
-    defer handle.close()
-    while handle.next() is Some(entry) {
-      let path = Path::join(dir, entry.name).to_string()
-      if entry.is_dir {
-        collect_js_in(path, js_paths)
-      } else if entry.name.has_suffix(".js") {
-        js_paths.push(path)
-      }
-    }
-  }
-
-  let js_paths = []
-  guard @fs.exists(dir) else { js_paths }
-  collect_js_in(dir, js_paths)
-  js_paths
-}
-
-///|
-fn[A] abort(s : String) -> A {
-  println(s)
-  panic()
+  inspect(rejected, content="true")
 }

--- a/warren/moon.mod
+++ b/warren/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/warren"
 
-version = "0.2.7"
+version = "0.3.0"
 
 import {
   "moonbitlang/async@0.19.3",

--- a/warren/moon.mod
+++ b/warren/moon.mod
@@ -5,7 +5,7 @@ version = "0.3.0"
 import {
   "moonbitlang/async@0.19.3",
   "moonbitlang/parser@0.2.5",
-  "moonbitlang/x@0.4.50",
+  "moonbitlang/x@0.5.1",
 }
 
 readme = "README.md"

--- a/warren/moon.pkg
+++ b/warren/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/core/argparse",
   "moonbitlang/core/env",
+  "moonbitlang/core/json",
   "moonbitlang/core/string",
   "moonbit-community/warren/log",
   "moonbit-community/warren/path",

--- a/warren/new_project.mbt
+++ b/warren/new_project.mbt
@@ -106,26 +106,55 @@ async fn write_template_entry(
 }
 
 ///|
-async fn new_project(dir : String, template_name : String) -> Unit {
-  let target_dir = Path::resolve(dir).to_string()
-  let project_name = Path::basename(target_dir).to_owned()
+async fn new_project(
+  project_root : SourcePath,
+  dir : String,
+  template_name : String,
+) -> Unit {
+  let project_root_string = source_path_to_string(project_root)
+  let requested_target = resolve_from(project_root_string, dir)
+  let requested_relative = Path::relative(
+    requested_target,
+    base=project_root_string,
+  ).to_string()
+  let project_name = Path::basename(requested_target).to_owned()
   let template_dir = match template_name {
     "default" => default_template_dir
     "minimized" => minimized_template_dir
-    _ => {
-      println(
+    _ =>
+      fail(
         "Unknown template `\{template_name}`. Available templates: default, minimized.",
       )
-      return
-    }
   }
   guard is_valid_project_name(project_name) else {
-    abort(
+    fail(
       "Invalid project directory name `\{project_name}`. Avoid spaces, path separators, and quotes.",
     )
   }
-  guard !@fs.exists(target_dir) else {
-    abort("Target path already exists: \{target_dir}")
+  guard path_is_inside(requested_target, project_root_string, allow_equal=false) else {
+    fail("New project directory must stay inside -C `\{project_root_string}`.")
+  }
+  guard !protected_output_path(requested_relative) else {
+    fail("Refusing dangerous new project path: \{requested_target}")
+  }
+  guard !@fs.exists(requested_target) else {
+    fail("Target path already exists: \{requested_target}")
+  }
+  let (lexical_parent, canonical_parent) = nearest_existing_parent(
+    requested_target,
+  )
+  guard @fs.kind(canonical_parent) is Directory else {
+    fail("New project parent is not a directory: \{lexical_parent}")
+  }
+  let target_dir = rebuild_from_canonical_parent(
+    requested_target, lexical_parent, canonical_parent,
+  )
+  guard path_is_inside(target_dir, project_root_string, allow_equal=false) else {
+    fail("New project directory resolves outside -C: \{requested_target}")
+  }
+  let target_relative = Path::relative(target_dir, base=project_root_string).to_string()
+  guard !protected_output_path(target_relative) else {
+    fail("Refusing dangerous new project path: \{requested_target}")
   }
 
   @fs.mkdir(target_dir, permission=0o755, recursive=true)
@@ -135,7 +164,8 @@ async fn new_project(dir : String, template_name : String) -> Unit {
   println("")
   println("Next steps:")
   println("  cd \{target_dir}")
-  println("  warren dev")
+  let browser_entry = if template_name == "default" { "main" } else { "." }
+  println("  warren dev --browser-entry \{browser_entry}")
 }
 
 ///|

--- a/warren/pkg.generated.mbti
+++ b/warren/pkg.generated.mbti
@@ -6,8 +6,6 @@ import {
 }
 
 // Values
-pub async fn build_project(@path.SourcePath, dist_dir? : @path.SourcePath) -> Unit
-
 pub async fn copy(src~ : @path.SourcePath, dst~ : @path.SourcePath) -> Unit
 
 pub fn debug_log(String, String) -> Unit
@@ -17,6 +15,8 @@ pub let templates : TemplatesFixture
 // Errors
 
 // Types and methods
+type ArtifactDigest derive(Eq)
+
 pub struct DefaultFixture {
   main : MainFixture
   public : PublicFixture
@@ -35,10 +35,16 @@ pub struct MinimizedFixture {
   moon_pkg : String
 }
 
+type ProjectLayout
+
 pub struct PublicFixture {
   index_html : String
   styles_css : String
 }
+
+type RunningServer
+
+type ServerTarget
 
 type TemplateEntry
 

--- a/warren/scripts/update_devtool_js.mbtx
+++ b/warren/scripts/update_devtool_js.mbtx
@@ -60,15 +60,29 @@ async fn find_warren_root() -> String {
 ///|
 async fn run_warren_build(root : String) -> Unit {
   let moon_bin = env_or("MOON_BIN", "moon")
-  let devtool_dir = join_path(root, "devtool")
   let code = @process.run(
     moon_bin,
-    ["run", "--target", "native", root, "--", "build", ".", "--dist", "./dist"],
-    cwd=devtool_dir,
+    [
+      "run",
+      "--target",
+      "native",
+      root,
+      "--",
+      "-C",
+      "devtool",
+      "build",
+      "--browser-entry",
+      ".",
+      "--public-dir",
+      "public",
+      "--dist",
+      "dist",
+    ],
+    cwd=root,
     inherit_env=true,
   )
   guard code == 0 else {
-    abort("`warren build ./devtool` failed with exit code \{code}")
+    abort("`warren -C devtool build --browser-entry .` failed with exit code \{code}")
   }
 }
 

--- a/warren/templates/default/README.md
+++ b/warren/templates/default/README.md
@@ -5,7 +5,7 @@
 In this directory:
 
 ```sh
-warren dev
+warren dev --browser-entry main
 ```
 
 Then open the local URL shown by warren.

--- a/warren/templates/default/public/index.html
+++ b/warren/templates/default/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>__WARREN_PROJECT_NAME__</title>
     <link rel="stylesheet" type="text/css" href="./styles.css"></link>
-    <script src="./index.js" type="module"></script>
+    <script src="/index.js" type="module"></script>
 </head>
 <body>
     <div id="app"></div>

--- a/warren/templates_bundle.mbt
+++ b/warren/templates_bundle.mbt
@@ -72,7 +72,7 @@ let _embed_index_html : String =
   #|    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   #|    <title>__WARREN_PROJECT_NAME__</title>
   #|    <link rel="stylesheet" type="text/css" href="./styles.css"></link>
-  #|    <script src="./index.js" type="module"></script>
+  #|    <script src="/index.js" type="module"></script>
   #|</head>
   #|<body>
   #|    <div id="app"></div>
@@ -205,7 +205,7 @@ let _embed_readme_md : String =
   #|In this directory:
   #|
   #|```sh
-  #|warren dev
+  #|warren dev --browser-entry main
   #|```
   #|
   #|Then open the local URL shown by warren.

--- a/website/homepage/README.md
+++ b/website/homepage/README.md
@@ -13,7 +13,7 @@ moon install moonbit-community/warren
 
 ```sh
 moon run --target native scripts/assets.mbtx
-warren dev main --public-dir public
+warren dev --browser-entry main --public-dir public
 ```
 
 The component showcase is served by the same application at `/components/`.
@@ -22,5 +22,5 @@ The component showcase is served by the same application at `/components/`.
 
 ```sh
 moon run --target native scripts/assets.mbtx
-warren build main --dist dist
+warren build --browser-entry main --dist dist
 ```

--- a/website/homepage/main/main.mbt
+++ b/website/homepage/main/main.mbt
@@ -903,7 +903,9 @@ fn quickstart() -> Val[Html] {
     "1", "Install Warren", "moon install moonbit-community/warren",
   )
   let create = qs_step("2", "Create the app", "warren new my-app\ncd my-app")
-  let run = qs_step("3", "Start the dev server", "warren dev")
+  let run = qs_step(
+    "3", "Start the dev server", "warren dev --browser-entry main",
+  )
   install.map3(create, run, (install, create, run) => {
     section(class="quickstart", [
       div(class="quickstart-inner", [

--- a/website/playground/README.md
+++ b/website/playground/README.md
@@ -15,7 +15,7 @@ cd website/playground
 export MOONBIT_PLAYGROUND_CORE_BUNDLE="$HOME/.moon/lib/core/_build/js/release/bundle"
 
 moon run --target native scripts/assets.mbtx
-warren dev main --public-dir public --port 4300
+warren dev --browser-entry main --public-dir public --port 4300
 ```
 
 Open: `http://127.0.0.1:4300`
@@ -27,7 +27,7 @@ cd website/playground
 export MOONBIT_PLAYGROUND_CORE_BUNDLE="$HOME/.moon/lib/core/_build/js/release/bundle"
 
 moon run --target native scripts/assets.mbtx
-warren build main --dist dist
+warren build --browser-entry main --dist dist
 ```
 
 Only CI/release build writes `dist/`. `MOON_BIN` can override `moon`.


### PR DESCRIPTION
## Summary

- add full-stack support to `warren dev` and `warren build` using the conventional `cmd/browser` and optional `cmd/server` entries
- add `-C`, configurable browser/server entries, safe public/dist path handling, and native or wasm server targets (wasm by default)
- rebuild browser assets and static output before rebuilding the server during development, and restart the server only when its artifact changes or the process has exited
- add `moonbit-community/rabbita/server`, backed by Moonback, for static serving, optional SSR rendering, and Warren development-client injection
- update template, example, and website usage instructions for Warren 0.3, and bump Rabbita to 0.15.3

## Why

Warren previously assumed a browser-only project with a positional main-package directory and its own preview server. That model could not run a MoonBit backend alongside the browser bundle, and it tied project discovery to legacy CLI behavior.

This change makes the project root and entry packages explicit, treats Moon's `--build-only` JSON output as the artifact contract, and lets an application-owned server serve the generated browser assets.

## Behavior and impact

- the browser entry defaults to `cmd/browser`, must exist, and always builds for JS
- the server entry defaults to an existing `cmd/server`; `--server-entry` overrides the entry and `--server-target native|wasm` selects its target
- `WARREN_MODE`, `WARREN_PORT`, `WARREN_CLIENT`, and `WARREN_DIST` provide the development contract to application servers
- browser-only projects keep the built-in preview server, diagnostics, live reload, and `--direct` mode
- full-stack projects run their own server; Warren exposes the reload client through `WARREN_CLIENT`, and the new Rabbita server package can inject it into generated or static HTML
- build output is recreated under the project root and contains browser assets plus exactly one server artifact when a server entry is present

## Breaking change

- remove the positional `main-package-dir` argument and the old `main`/cwd fallback; use `--browser-entry`

## Validation

- GitHub Actions: `stable-build`, `typo-check`, and `vite-plugin` pass
- `moon fmt --check`
- `moon check --target all` for the Warren and Rabbita modules: 0 errors
- `moon test --target js`: 71 passed
- `moon test --target native`: 74 passed
- `moon test --target wasm`: 52 passed
- `moon info`: no unexpected interface changes
- manually exercised full-stack `warren build` and `warren dev`, including SSR, browser asset injection, and wasm server startup

## Known issue

The changed `examples/document` module does not currently pass a standalone native check: `oboard/mocket@0.7.7` expects the pre-0.21 async HTTP header map while the module now pins `moonbitlang/async@0.21.0`. The focused Warren/Rabbita checks and the PR's GitHub Actions checks pass.
