### PR TITLE
fix(warren): skip chmod on Windows in install/build

### DIFF
--- a/warren/build.mbt
+++ b/warren/build.mbt
@@ -348,7 +348,7 @@ async fn copy_server_artifact(
   }
   copy(src=artifact, dst=output)
   if target is Native {
-    @fs.chmod(source_path_to_string(output), 0o755)
+    chmod_executable(output)
   }
   output
 }

--- a/warren/dev.mbt
+++ b/warren/dev.mbt
@@ -192,7 +192,7 @@ async fn stage_native_server(
   let executable = directory.join(basename)
   if !@fs.exists(source_path_to_string(executable)) {
     copy(src=artifact, dst=executable)
-    @fs.chmod(source_path_to_string(executable), 0o755)
+    chmod_executable(executable)
   }
   executable
 }

--- a/warren/utils.mbt
+++ b/warren/utils.mbt
@@ -25,3 +25,15 @@ pub async fn copy(src~ : SourcePath, dst~ : SourcePath) -> Unit {
     writer.write_reader(reader)
   }
 }
+
+///|
+#cfg(not(platform="windows"))
+pub async fn chmod_executable(path : SourcePath) -> Unit {
+  @fs.chmod(source_path_to_string(path), 0o755)
+}
+
+///|
+#cfg(platform="windows")
+pub async fn chmod_executable(_path : SourcePath) -> Unit {
+  ignore(_path)
+}


### PR DESCRIPTION
## Problem

`moon install moonbit-community/warren` fails on Windows with:

```
Error: [4021]
build.mbt:351: @fs.chmod(source_path_to_string(output), 0o755)
dev.mbt:195: @fs.chmod(source_path_to_string(executable), 0o755)
Value chmod not found in package `fs`.
```

`@fs.chmod` in `moonbitlang/async@0.19.3` (the version pinned by warren) is guarded by `#cfg(not(platform="windows"))`, so the symbol does not exist on Windows. warren's build script is compiled on the host during `moon install`, so installation fails on Windows.

## Fix

Since `#cfg` cannot annotate inline statements, add cfg-guarded helper functions following the existing pattern in `warren/devhub/devhub.mbt`:

- `warren/utils.mbt`: add `chmod_executable`, which calls `@fs.chmod(..., 0o755)` on non-Windows and is a no-op on Windows.
- `warren/build.mbt` and `warren/dev.mbt`: replace direct `@fs.chmod` calls with `chmod_executable`.

Windows does not use POSIX permission bits, so skipping is a no-op there.

## Verification

- `moon build warren` passes
- `moon test warren` passes (26/26)

Closes #157