### PR TITLE
fix: resolve mount targets before runtime initialization

### DIFF
--- a/rabbita/internal/runtime/host_browser.mbt
+++ b/rabbita/internal/runtime/host_browser.mbt
@@ -21,9 +21,10 @@ struct BrowserHost {
 
 ///|
 pub fn BrowserHost::BrowserHost(
-  element_id? : String,
+  element_id~ : String,
   builder : GraphBuilder,
 ) -> Self {
+  let target_element = @dom.document().get_element_by_id(element_id).unwrap()
   let (host, output) = @duplix.with_scope(scope => {
     let host = BrowserHost::{
       stores: SlotMap(),
@@ -44,9 +45,7 @@ pub fn BrowserHost::BrowserHost(
   let cmd = Context::inject_url_changed(host, url)
   Scheduler::queue_command(host, cmd)
   let root = ambient_host.protect(host, () => output.read())
-  host.document = Some(
-    @vdom.VDom::initialize(root, host, target_element_id?=element_id),
-  )
+  host.document = Some(@vdom.VDom::mount(root, host, target_element))
   host.drain_scheduled = false
   host
 }

--- a/rabbita/internal/runtime/host_browser_wbtest.mbt
+++ b/rabbita/internal/runtime/host_browser_wbtest.mbt
@@ -1,0 +1,39 @@
+///|
+#cfg(target="js")
+extern "js" fn with_missing_mount_target(run : () -> Unit) -> Bool =
+  #| (run) => {
+  #|   const hadWindow = Object.prototype.hasOwnProperty.call(globalThis, "window")
+  #|   const hadDocument = Object.prototype.hasOwnProperty.call(globalThis, "document")
+  #|   const previousWindow = globalThis.window
+  #|   const previousDocument = globalThis.document
+  #|   globalThis.window = { location: { href: "http://localhost/" } }
+  #|   globalThis.document = { getElementById: () => null }
+  #|   try {
+  #|     run()
+  #|     return false
+  #|   } catch (_) {
+  #|     return true
+  #|   } finally {
+  #|     if (hadWindow) globalThis.window = previousWindow
+  #|     else delete globalThis.window
+  #|     if (hadDocument) globalThis.document = previousDocument
+  #|     else delete globalThis.document
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+test "missing mount target is rejected before the builder runs" {
+  let mut builder_ran = false
+  let rejected = with_missing_mount_target(() => {
+    ignore(
+      BrowserHost(element_id="missing", () => {
+        builder_ran = true
+        @duplix.constant(@vdom.VNode::text("unreachable"))
+      }),
+    )
+  })
+
+  inspect(rejected, content="true")
+  inspect(builder_ran, content="false")
+}

--- a/rabbita/internal/runtime/host_hydration.mbt
+++ b/rabbita/internal/runtime/host_hydration.mbt
@@ -55,7 +55,7 @@ pub fn HydrationHost::HydrationHost(builder : GraphBuilder) -> HydrationHost {
     }
   }
 
-  let vdom = @vdom.VDom::initialize_with_hydration(vnode, host)
+  let vdom = @vdom.VDom::hydrate(vnode, host)
   host.browser.document = Some(vdom)
   host.browser.drain_scheduled = false
   host

--- a/rabbita/internal/runtime/host_ssr.mbt
+++ b/rabbita/internal/runtime/host_ssr.mbt
@@ -64,7 +64,7 @@ pub async fn SSRHost::SSRHost(
     }
   }
 
-  host.document = Some(@vdom.VDom::initialize(vnode, host))
+  host.document = Some(@vdom.VDom::from_vnode(vnode))
   errdefer host.cleanup()
   host
 }

--- a/rabbita/internal/runtime/pkg.generated.mbti
+++ b/rabbita/internal/runtime/pkg.generated.mbti
@@ -21,7 +21,7 @@ pub fn[Model : Eq, Msg, Input : Eq] create_state_machine_with_input((@cmd.Emit[M
 
 // Types and methods
 type BrowserHost
-pub fn BrowserHost::BrowserHost(element_id? : String, () -> @duplix.Node[@vdom.VNode]) -> Self
+pub fn BrowserHost::BrowserHost(element_id~ : String, () -> @duplix.Node[@vdom.VNode]) -> Self
 pub impl @cmd.Context for BrowserHost
 pub impl @cmd.Scheduler for BrowserHost
 pub impl Host for BrowserHost

--- a/rabbita/internal/vdom/diff.mbt
+++ b/rabbita/internal/vdom/diff.mbt
@@ -329,10 +329,7 @@ pub fn VDom::update(self : Self, vnode : VNode, _ : &Scheduler) -> Unit {
 
 ///|
 #cfg(target="js")
-pub fn VDom::initialize_with_hydration(
-  vnode : VNode,
-  scheduler : &Scheduler,
-) -> VDom {
+pub fn VDom::hydrate(vnode : VNode, scheduler : &Scheduler) -> VDom {
   let captured_link_listener = new_captured_link_listener(scheduler)
   let inode = hydrate_root(vnode, scheduler, captured_link_listener)
   { inode, captured_link_listener, target_element: None }
@@ -359,93 +356,26 @@ fn new_captured_link_listener(scheduler : &Scheduler) -> @dom.Listener {
 
 ///|
 #cfg(target="js")
-pub fn VDom::initialize(
+pub fn VDom::mount(
   vnode : VNode,
   scheduler : &Scheduler,
-  target_element_id? : String,
+  container : @dom.Element,
 ) -> VDom {
   let captured_link_listener = new_captured_link_listener(scheduler)
-  match (target_element_id, vnode) {
-    (Some(id), vnode) => {
-      let container = @dom.document().get_element_by_id(id).unwrap()
-      // Clear any existing DOM so mounting does not append beside stale content.
-      container.set_inner_html("")
-      let inode = vnode.insert(
-        scheduler,
-        captured_link_listener,
-        container.as_node(),
-        null(),
-      )
-      VDom::{ target_element: Some(container), inode, captured_link_listener }
-    }
-    (
-      None,
-      Elem(
-        "html",
-        props,
-        Array(
-          [
-            Elem("head", head_props, head_children, ..),
-            Elem("body", body_props, body_children, ..),
-          ]
-        ),
-        namespace_uri=None
-      ),
-    ) => {
-      let head = {
-        let element = @dom.document().get_head().unwrap().as_element()
-        let props = insert_props(
-          element, "head", head_props, scheduler, captured_link_listener,
-        )
-        let children = insert_children(
-          element.as_node(),
-          head_children,
-          scheduler,
-          captured_link_listener,
-        )
-        INode::Elem("head", props, children, namespace_uri=None, element)
-      }
-      let body = {
-        let element = @dom.document().get_body().unwrap().as_element()
-        let props = insert_props(
-          element, "body", body_props, scheduler, captured_link_listener,
-        )
-        let children = insert_children(
-          element.as_node(),
-          body_children,
-          scheduler,
-          captured_link_listener,
-        )
-        INode::Elem("body", props, children, namespace_uri=None, element)
-      }
-
-      let html = @dom.document().get_document_element().unwrap()
-      let props = insert_props(
-        html, "html", props, scheduler, captured_link_listener,
-      )
-      let inode = INode::Elem(
-        "html",
-        props,
-        Array([head, body]),
-        html,
-        namespace_uri=None,
-      )
-      VDom::{ target_element: None, inode, captured_link_listener }
-    }
-    // VDom root invariant: the root must be either a `(Some(id), _)` or a 
-    // `(None, Elem("html", _, Array([Elem("head", ..), Elem("body", ..)]), ..)`
-    (_, Elem(_) | Text(_) | Frag(_) | Thunk(_)) => panic()
-  }
+  // Clear any existing DOM so mounting does not append beside stale content.
+  container.set_inner_html("")
+  let inode = vnode.insert(
+    scheduler,
+    captured_link_listener,
+    container.as_node(),
+    null(),
+  )
+  { target_element: Some(container), inode, captured_link_listener }
 }
 
 ///|
 #cfg(not(target="js"))
-pub fn VDom::initialize(
-  vnode : VNode,
-  _ : &Scheduler,
-  target_element_id? : String,
-) -> VDom {
-  ignore(target_element_id)
+pub fn VDom::from_vnode(vnode : VNode) -> VDom {
   { vnode, }
 }
 
@@ -525,7 +455,8 @@ fn diff_document(
         container.as_node(),
         null(),
       )
-    // See VDom root invariant in `VDom::initialize`
+    // Hydrated VDOM root invariant: updates may change properties and children, but
+    // must preserve the existing `html` root and its `head` and `body` elements.
     _ => panic()
   }
 }

--- a/rabbita/internal/vdom/pkg.generated.mbti
+++ b/rabbita/internal/vdom/pkg.generated.mbti
@@ -29,8 +29,8 @@ pub fn Props::copy(Self) -> Self
 pub fn Props::new(Map[String, String], Map[String, @variant.Variant], Map[String, String], Map[String, (@dom.Event, &@cmd.Scheduler) -> Unit]) -> Self
 
 type VDom
-pub fn VDom::initialize(VNode, &@cmd.Scheduler, target_element_id? : String) -> Self
-pub fn VDom::initialize_with_hydration(VNode, &@cmd.Scheduler) -> Self
+pub fn VDom::hydrate(VNode, &@cmd.Scheduler) -> Self
+pub fn VDom::mount(VNode, &@cmd.Scheduler, @dom.Element) -> Self
 pub fn VDom::to_string(Self) -> String
 pub fn VDom::update(Self, VNode, &@cmd.Scheduler) -> Unit
 

--- a/rabbita/top.mbt
+++ b/rabbita/top.mbt
@@ -61,7 +61,7 @@ pub fn App::mount(self : Self, element_id : String) -> Unit {
 ///|
 #cfg(not(target="js"))
 fn split_url(url : String) -> (String, String) raise {
-  let { protocol, host, path, port, query, fragment } = @url.parse(url)
+  let { protocol, host, path, port, query, fragment, } = @url.parse(url)
   let protocol = match protocol {
     Http => "http"
     Https => "https"


### PR DESCRIPTION
Resolve browser mount targets before runtime initialization.

Missing targets now fail before Rabbita creates the Duplix scope or evaluates the application builder. The resolved element is passed directly to the VDOM, so target validation and mounting use the same container identity.

The VDOM constructors now reflect each runtime host's responsibility:

| Host | Operation |
| --- | --- |
| `BrowserHost` | Mount into a container |
| `HydrationHost` | Hydrate an existing document |
| `SSRHost` | Render without browser DOM access |

This also removes the unused container-less browser path. Valid mounts, hydration, and server-side rendering keep their existing behavior.

## Behavior

| Scenario | Result |
| --- | --- |
| The target element exists | Mounting works as before |
| The target element is missing | Mounting fails before the builder runs |
| Hydration | Continues through the hydration-specific path |
| Server-side rendering | Continues without a DOM target |

## Tests

Added a regression test confirming that a missing target is rejected before the application builder runs.