### PR TITLE
fix(dom): accept cross-realm pointer events

### DIFF
--- a/e2e/apps/dom-api/probe_events.mbt
+++ b/e2e/apps/dom-api/probe_events.mbt
@@ -134,6 +134,11 @@ fn install_generic_event_probe(target : @dom.Element) -> Unit {
   )
   record(
     failures,
+    @dom.IsEvent::to_mouse_event(first) is None,
+    "generic_not_mouse_event",
+  )
+  record(
+    failures,
     physical_equal(@dom.IsEvent::as_event(first), first),
     "as_event",
   )
@@ -170,6 +175,11 @@ fn install_fractional_pointer_event_probe(target : @dom.Element) -> Unit {
   let listener : @dom.Listener = event => {
     let failures : Array[String] = []
     if @dom.IsEvent::to_pointer_event(event) is Some(pointer) {
+      record(
+        failures,
+        @dom.IsEvent::to_mouse_event(pointer) is Some(_),
+        "pointer_fractional_mouse_event",
+      )
       record(
         failures,
         pointer.get_client_x() == 10.25 && pointer.get_client_y() == 20.75,

--- a/e2e/tests/dom-api.spec.ts
+++ b/e2e/tests/dom-api.spec.ts
@@ -114,20 +114,27 @@ test('event targets and concrete browser event subtypes expose their native fiel
   expect(await page.evaluate(() => sessionStorage.getItem('dom-api-beforeunload'))).toBe('passed');
 });
 
-test('pointer coordinate bindings preserve fractional CSS pixels', async ({ page }) => {
+test('pointer event casts accept iframe realm events and preserve fractional CSS pixels', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('button', { name: 'Install event API probes' }).click();
 
   await page.locator('#event-target').evaluate((target) => {
-    target.dispatchEvent(new PointerEvent('fractional-pointer-probe', {
-      pointerId: 7,
-      pointerType: 'mouse',
-      isPrimary: true,
-      clientX: 10.25,
-      clientY: 20.75,
-      screenX: 30.5,
-      screenY: 40.125,
-    }));
+    const iframe = document.createElement('iframe');
+    document.body.append(iframe);
+    try {
+      const iframeWindow = iframe.contentWindow as Window & typeof globalThis;
+      target.dispatchEvent(new iframeWindow.PointerEvent('fractional-pointer-probe', {
+        pointerId: 7,
+        pointerType: 'mouse',
+        isPrimary: true,
+        clientX: 10.25,
+        clientY: 20.75,
+        screenX: 30.5,
+        screenY: 40.125,
+      }));
+    } finally {
+      iframe.remove();
+    }
   });
 
   await expect(page.locator('#event-fractional-pointer-result')).toHaveText('passed');

--- a/rabbita/dom/event.mbt
+++ b/rabbita/dom/event.mbt
@@ -276,16 +276,46 @@ extern "js" fn ffi_event_stop_immediate_propagation(x : Event) = "(self) => self
 ///|
 #cfg(target="js")
 extern "js" fn ffi_to_mouse_event(x : @js.Value) -> @js.Nullable[MouseEvent] =
-  #| (e) => e instanceof MouseEvent ? e : null
+  #| (event) => {
+  #|   if (typeof MouseEvent === "undefined") {
+  #|     return null
+  #|   }
+  #|   if (event instanceof MouseEvent) {
+  #|     return event
+  #|   }
+  #|   try {
+  #|     // Web IDL operations validate the interface brand across realms.
+  #|     MouseEvent.prototype.getModifierState.call(event, "")
+  #|     return event
+  #|   } catch {
+  #|     return null
+  #|   }
+  #| }
 
 ///|
 #cfg(target="js")
 extern "js" fn ffi_to_pointer_event(
   x : @js.Value,
 ) -> @js.Nullable[PointerEvent] =
-  #| (e) => typeof PointerEvent !== "undefined" && e instanceof PointerEvent
-  #|   ? e
-  #|   : null
+  #| (event) => {
+  #|   if (typeof PointerEvent === "undefined") {
+  #|     return null
+  #|   }
+  #|   if (event instanceof PointerEvent) {
+  #|     return event
+  #|   }
+  #|   try {
+  #|     // Use the native getter as a realm-independent brand check.
+  #|     const getPointerId = Object.getOwnPropertyDescriptor(
+  #|       PointerEvent.prototype,
+  #|       "pointerId",
+  #|     ).get
+  #|     getPointerId.call(event)
+  #|     return event
+  #|   } catch {
+  #|     return null
+  #|   }
+  #| }
 
 ///|
 #cfg(target="js")

--- a/rabbita/top.mbt
+++ b/rabbita/top.mbt
@@ -61,7 +61,7 @@ pub fn App::mount(self : Self, element_id : String) -> Unit {
 ///|
 #cfg(not(target="js"))
 fn split_url(url : String) -> (String, String) raise {
-  let { protocol, host, path, port, query, fragment } = @url.parse(url)
+  let { protocol, host, path, port, query, fragment, } = @url.parse(url)
   let protocol = match protocol {
     Http => "http"
     Https => "https"


### PR DESCRIPTION
## Summary

- keep the existing same-realm `instanceof` fast paths for mouse and pointer event casts
- fall back to native Web IDL brand checks so events created by an iframe realm are recognized without accepting lookalike objects
- extend the DOM API browser probe to cover both `PointerEvent` and inherited `MouseEvent` conversion for an iframe-created event
- verify that a plain `Event` is still rejected as both event subtypes

Closes #164

## Testing

- `moon fmt --check .`
- `npx playwright test tests/dom-api.spec.ts --project=dom-api-chromium` — 11 passed
- `CI=1 npm test -- --reporter=list` — 126 passed

## Formatting note

The current MoonBit formatter also adds a required trailing comma to one pre-existing destructuring pattern in `rabbita/top.mbt`. That isolated mechanical change is included because the check workflow formats the whole package and requires a clean diff.
