### PR TITLE
feat(warren): support mbtx browser entries

### DIFF
--- a/examples/mbtx-counter/README.md
+++ b/examples/mbtx-counter/README.md
@@ -1,0 +1,10 @@
+# MBTX Counter
+
+A single-file Rabbita counter.
+
+```sh
+moon install moonbit-community/warren
+warren dev page.mbtx
+```
+
+Build it with `warren build page.mbtx`.

--- a/examples/mbtx-counter/page.mbtx
+++ b/examples/mbtx-counter/page.mbtx
@@ -1,0 +1,32 @@
+import {
+  "moonbit-community/rabbita@0.15.4",
+  "moonbit-community/rabbita@0.15.4/html" @html,
+}
+
+///|
+priv enum Msg {
+  Increment
+  Decrement
+}
+
+///|
+fn app() -> @rabbita.Val[@rabbita.Html] {
+  let (count, emit) = @rabbita.create_pure_state(0, update=fn(count, msg) {
+    match msg {
+      Increment => count + 1
+      Decrement => count - 1
+    }
+  })
+  count.view(count => {
+    @html.div([
+      @html.h1(count.to_string()),
+      @html.button(on_click=emit(Decrement), "-"),
+      @html.button(on_click=emit(Increment), "+"),
+    ])
+  })
+}
+
+///|
+fn main {
+  @rabbita.new(app).mount("app")
+}

--- a/rabbita/top.mbt
+++ b/rabbita/top.mbt
@@ -61,7 +61,7 @@ pub fn App::mount(self : Self, element_id : String) -> Unit {
 ///|
 #cfg(not(target="js"))
 fn split_url(url : String) -> (String, String) raise {
-  let { protocol, host, path, port, query, fragment } = @url.parse(url)
+  let { protocol, host, path, port, query, fragment, } = @url.parse(url)
   let protocol = match protocol {
     Http => "http"
     Https => "https"

--- a/vite-plugin/package.json
+++ b/vite-plugin/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "vite": "^7.0.0"
   },
+  "overrides": {
+    "postcss": "8.5.26"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/warren/README.md
+++ b/warren/README.md
@@ -24,6 +24,13 @@ warren dev --browser-entry frontend --server-entry backend
 warren build --browser-entry frontend --server-entry backend
 ```
 
+Standalone `.mbtx` files can also be used as browser entries:
+
+```sh
+warren dev page.mbtx
+warren build page.mbtx
+```
+
 Pass an empty server entry to ignore an existing `cmd/server` and select the
 browser-only workflow. The browser entry cannot be empty.
 

--- a/warren/config.mbt
+++ b/warren/config.mbt
@@ -241,6 +241,46 @@ async fn resolve_project_layout(
 }
 
 ///|
+async fn resolve_mbtx_layout(
+  root : SourcePath,
+  raw : String,
+  public_dir_raw : String?,
+) -> ProjectLayout {
+  guard raw.has_suffix(".mbtx") else {
+    fail("Standalone browser entry must use the `.mbtx` extension.")
+  }
+  let root_string = source_path_to_string(root)
+  let candidate = resolve_from(root_string, raw)
+  guard @fs.exists(candidate) else {
+    fail("Standalone browser entry does not exist.")
+  }
+  let canonical = @fs.realpath(candidate)
+  guard @fs.kind(canonical) is Regular else {
+    fail("Standalone browser entry must be a regular file.")
+  }
+  guard path_is_inside(canonical, root_string, allow_equal=false) else {
+    fail("Standalone browser entry must stay inside the project root.")
+  }
+  let public_dir = match public_dir_raw {
+    Some(value) => Some(resolve_input_dir(root, value, "Public"))
+    None => {
+      let conventional = resolve_from(root_string, "public")
+      if @fs.exists(conventional) {
+        Some(resolve_input_dir(root, "public", "Public"))
+      } else {
+        None
+      }
+    }
+  }
+  {
+    root,
+    browser_entry: SourcePath::new(canonical),
+    server_entry: None,
+    public_dir,
+  }
+}
+
+///|
 fn parse_server_target(raw : String?) -> ServerTarget raise {
   match raw {
     None | Some("wasm") => Wasm

--- a/warren/main.mbt
+++ b/warren/main.mbt
@@ -99,6 +99,11 @@ fn warren_cli() -> @argparse.Command {
     subcommands=[
       Command(
         "dev",
+        positionals=[
+          PositionArg("mbtx", about="Standalone .mbtx browser entry.", conflicts_with=[
+            "browser-entry", "server-entry", "server-target",
+          ]),
+        ],
         options=[
           OptionArg(
             "browser-entry",
@@ -128,6 +133,11 @@ fn warren_cli() -> @argparse.Command {
       ),
       Command(
         "build",
+        positionals=[
+          PositionArg("mbtx", about="Standalone .mbtx browser entry.", conflicts_with=[
+            "browser-entry", "server-entry", "server-target",
+          ]),
+        ],
         options=[
           OptionArg(
             "browser-entry",
@@ -200,15 +210,20 @@ async fn run_cli() -> Unit {
     None => option_value(cli, "directory")
   }
   let root = effective_root(directory)
+  let mbtx_entry = option_value(submatches, "mbtx")
   match subcmd {
     "dev" => {
       let direct = submatches.flags.get("direct") is Some(true)
-      let layout = resolve_project_layout(
-        root,
-        option_value(submatches, "browser-entry"),
-        dev_server_entry_value(submatches),
-        option_value(submatches, "public-dir"),
-      )
+      let layout = if mbtx_entry is Some(raw) {
+        resolve_mbtx_layout(root, raw, option_value(submatches, "public-dir"))
+      } else {
+        resolve_project_layout(
+          root,
+          option_value(submatches, "browser-entry"),
+          dev_server_entry_value(submatches),
+          option_value(submatches, "public-dir"),
+        )
+      }
       let target_raw = option_value(submatches, "server-target")
       let server_target = parse_server_target(target_raw)
       if target_raw is Some(_) && layout.server_entry is None {
@@ -218,12 +233,16 @@ async fn run_cli() -> Unit {
       dev_project(layout, server_target, port, direct)
     }
     "build" => {
-      let layout = resolve_project_layout(
-        root,
-        option_value(submatches, "browser-entry"),
-        option_value(submatches, "server-entry"),
-        option_value(submatches, "public-dir"),
-      )
+      let layout = if mbtx_entry is Some(raw) {
+        resolve_mbtx_layout(root, raw, option_value(submatches, "public-dir"))
+      } else {
+        resolve_project_layout(
+          root,
+          option_value(submatches, "browser-entry"),
+          option_value(submatches, "server-entry"),
+          option_value(submatches, "public-dir"),
+        )
+      }
       let target_raw = option_value(submatches, "server-target")
       let server_target = parse_server_target(target_raw)
       if target_raw is Some(_) && layout.server_entry is None {
@@ -429,14 +448,4 @@ test "--direct conflicts with a non-empty server entry" {
     _ => false
   }
   assert_true(rejected)
-}
-
-///|
-test "CLI rejects the removed positional build entry" {
-  let rejected = try warren_cli().parse(argv=["build", "main"], env={}) catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
-  inspect(rejected, content="true")
 }

--- a/warren/mbtx_entry_wbtest.mbt
+++ b/warren/mbtx_entry_wbtest.mbt
@@ -1,0 +1,121 @@
+///|
+test "dev and build accept .mbtx entries" {
+  let dev = warren_cli().parse(argv=["dev", "page.mbtx"], env={})
+  guard dev.subcommand is Some(("dev", dev_matches)) else {
+    fail("expected dev subcommand")
+  }
+  assert_eq(option_value(dev_matches, "mbtx"), Some("page.mbtx"))
+  let build = warren_cli().parse(argv=["build", "page.mbtx"], env={})
+  guard build.subcommand is Some(("build", build_matches)) else {
+    fail("expected build subcommand")
+  }
+  assert_eq(option_value(build_matches, "mbtx"), Some("page.mbtx"))
+}
+
+///|
+test ".mbtx entries conflict with package and server options" {
+  for
+    argv in [
+      ["dev", "page.mbtx", "--browser-entry", "frontend"],
+      ["dev", "page.mbtx", "--server-entry", "backend"],
+      ["build", "page.mbtx", "--server-entry", ""],
+      ["build", "page.mbtx", "--server-target", "wasm"],
+      ["build", "page.mbtx", "--", "argument"],
+    ] {
+    let rejected = try warren_cli().parse(argv~, env={}) catch {
+      _ => true
+    } noraise {
+      _ => false
+    }
+    assert_true(rejected)
+  }
+}
+
+///|
+async test ".mbtx layout is browser-only and keeps public discovery" {
+  let root_string = @fs.tmpdir(prefix="warren-mbtx-layout")
+  let root = SourcePath::new(@fs.realpath(root_string))
+  let page = root.join("page.mbtx")
+  @fs.write_file(
+    source_path_to_string(page),
+    "fn main { println(\"page\") }\n",
+    create_mode=CreateOrTruncate,
+    permission=0o644,
+  )
+  @fs.mkdir(
+    source_path_to_string(root.join("cmd/server")),
+    permission=0o755,
+    recursive=true,
+  )
+  @fs.mkdir(source_path_to_string(root.join("public")), permission=0o755)
+  let layout = resolve_mbtx_layout(root, "page.mbtx", None)
+  assert_eq(layout.browser_entry, page)
+  assert_true(layout.server_entry is None)
+  assert_eq(layout.public_dir, Some(root.join("public")))
+  @fs.rmdir(root_string, recursive=true)
+}
+
+///|
+async test ".mbtx entry must be a regular file inside the project root" {
+  let root_string = @fs.tmpdir(prefix="warren-mbtx-entry")
+  let root = SourcePath::new(@fs.realpath(root_string))
+  @fs.mkdir(source_path_to_string(root.join("folder.mbtx")), permission=0o755)
+  let outside_string = @fs.tmpdir(prefix="warren-mbtx-outside")
+  let outside = Path::join(outside_string, "outside.mbtx").to_string()
+  @fs.write_file(
+    outside,
+    "fn main { println(\"outside\") }\n",
+    create_mode=CreateOrTruncate,
+    permission=0o644,
+  )
+  for raw in ["page.mbt", "missing.mbtx", "folder.mbtx", outside] {
+    let rejected = try resolve_mbtx_layout(root, raw, None) catch {
+      Failure(_) => true
+      _ => false
+    } noraise {
+      _ => false
+    }
+    assert_true(rejected)
+  }
+  @fs.rmdir(root_string, recursive=true)
+  @fs.rmdir(outside_string, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test ".mbtx symlinks must resolve inside the project root" {
+  let root_string = @fs.tmpdir(prefix="warren-mbtx-symlink")
+  let root = SourcePath::new(@fs.realpath(root_string))
+  let page = root.join("page.mbtx")
+  @fs.write_file(
+    source_path_to_string(page),
+    "fn main { println(\"page\") }\n",
+    create_mode=CreateOrTruncate,
+    permission=0o644,
+  )
+  let inside_link = root.join("inside.mbtx")
+  @fs.symlink(
+    target=source_path_to_string(page),
+    source_path_to_string(inside_link),
+  )
+  assert_eq(resolve_mbtx_layout(root, "inside.mbtx", None).browser_entry, page)
+  let outside_string = @fs.tmpdir(prefix="warren-mbtx-symlink-outside")
+  let outside = Path::join(outside_string, "outside.mbtx").to_string()
+  @fs.write_file(
+    outside,
+    "fn main { println(\"outside\") }\n",
+    create_mode=CreateOrTruncate,
+    permission=0o644,
+  )
+  let outside_link = root.join("outside.mbtx")
+  @fs.symlink(target=outside, source_path_to_string(outside_link))
+  let rejected = try resolve_mbtx_layout(root, "outside.mbtx", None) catch {
+    Failure(_) => true
+    _ => false
+  } noraise {
+    _ => false
+  }
+  assert_true(rejected)
+  @fs.rmdir(root_string, recursive=true)
+  @fs.rmdir(outside_string, recursive=true)
+}

--- a/warren/moon.mod
+++ b/warren/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/warren"
 
-version = "0.3.2"
+version = "0.3.3"
 
 import {
   "moonbitlang/async@0.19.3",


### PR DESCRIPTION
## Summary

- support standalone .mbtx browser entries with warren dev and warren build
- keep the existing package-directory workflow unchanged
- reject server options for browser-only .mbtx entries
- add concise documentation and a single-file counter example
- bump Warren to 0.3.3
- add no C FFI

## CI fixes

- apply the formatting required by the current stable MoonBit toolchain
- pin PostCSS to 8.5.26 because 8.5.27 ships a broken TypeScript declaration

## Validation

- moon check --warn-list +unnecessary_annotation (0 errors; 6 existing warnings)
- moon test (95 JS tests and 32 native tests passed)
- npm test in vite-plugin
- warren build page.mbtx
- warren dev page.mbtx --direct
- warren dev --browser-entry main against examples/counter
- GitHub Actions: stable-build, vite-plugin, e2e, and typo-check passed