### PR TITLE
url: drop the dead moonbitlang/core/strconv import; release 0.15.5

### DIFF
--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/rabbita"
 
-version = "0.15.4"
+version = "0.15.5"
 
 readme = "README.md"
 

--- a/rabbita/url/moon.pkg
+++ b/rabbita/url/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "moonbitlang/core/strconv",
   "moonbitlang/core/string",
 }
 


### PR DESCRIPTION
`url/moon.pkg` imported both `moonbitlang/core/strconv` and `moonbitlang/core/string`; the package's one parse (`url.mbt`, the port) already uses `@string.parse_int`. Nothing referenced `@strconv` — the import was dead.

It stopped being harmless with **core 0.10.12**, which removed `moonbitlang/core/strconv` (only `core/internal/strconv` remains). Any module depending on rabbita then fails package solving before compiling anything:

```
Cannot find import 'moonbitlang/core/strconv' in moonbit-community/rabbita/url@0.15.4
```

`core/string` has the same `parse_*` API in 0.10.11 and 0.10.12, so this builds on both. Version bumped to 0.15.5 for the release tag `rabbita-v0.15.5`.

Note: rabbita's own dependency `oboard/mocket@0.7.7` also imports the removed package, so this module still won't solve on core 0.10.12 until mocket releases a fix — this PR removes rabbita's share of the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc