### PR TITLE
ci: add a nightly toolchain canary

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,72 @@
+name: nightly-toolchain
+
+# Canary against the MoonBit nightly toolchain, so that breaking changes in the
+# compiler or in `moonbitlang/core` show up here instead of in a user's build.
+# `check.yml` stays on the stable toolchain and is the gate for pull requests.
+
+on:
+  schedule:
+    # 04:00 UTC, after the nightly toolchain and core have been published.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/nightly.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-toolchain-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install MoonBit nightly
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+      - name: MoonBit version
+        run: |
+          moon version --all
+          moonrun --version
+
+      - name: Update dependencies
+        run: moon update
+
+      # Every `moon.work` member, so a package that a nightly `core` release
+      # removed is caught while resolving imports, before anything compiles.
+      - name: Check workspace
+        run: |
+          set -o pipefail
+          for target in js native wasm; do
+            echo "::group::moon check --target $target"
+            moon check --target "$target" 2>&1 | tee -a "$RUNNER_TEMP/nightly-check.log"
+            echo "::endgroup::"
+          done
+
+      # Nightly deprecates APIs ahead of stable, so warnings here are a heads-up
+      # rather than a failure: `--deny-warn` is the stable job's gate, not ours.
+      - name: Warning summary
+        if: always()
+        run: |
+          {
+            echo "### \`moon check\` on $(moon version | head -n 1)"
+            echo
+            if [ -s "$RUNNER_TEMP/nightly-check.log" ]; then
+              echo '| count | warning |'
+              echo '| ----: | ------- |'
+              grep -o 'Warning ([a-z_]*)' "$RUNNER_TEMP/nightly-check.log" \
+                | sort | uniq -c | sort -rn \
+                | sed -E 's/^ *([0-9]+) Warning \((.*)\)$/| \1 | `\2` |/' \
+                || echo "| 0 | none |"
+            else
+              echo "No check output; the toolchain install or \`moon update\` failed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`moonbitlang/core` 0.10.12 removed `moonbitlang/core/strconv`. The dead import in `rabbita/url/moon.pkg` was harmless until then, and when it stopped being harmless it broke *consumers* — any module depending on rabbita failed package solving before a file was compiled. `check.yml` pins the stable toolchain, so nothing in CI saw it coming (#168 was the fix, found the hard way).

This adds a scheduled canary against the nightly toolchain.

## What it runs

Daily at 04:00 UTC, plus `workflow_dispatch`, plus `pull_request` on the workflow file itself so changes to it get exercised. It installs nightly via `install/unix.sh | bash -s nightly` and runs `moon check` for js, native, and wasm at the **workspace root** — which covers every `moon.work` member, so a package a nightly `core` release drops is caught while resolving imports.

## What it deliberately does not run

No `--deny-warn`, `moon fmt`, or `moon info`. Nightly deprecates ahead of stable and formats differently, so all three would fail for reasons that aren't regressions and the job would be permanently red. `check.yml` stays the gate for those. Warnings go into `$GITHUB_STEP_SUMMARY` as a count-by-kind table instead.

## Verification

Ran against nightly locally (`moonc v0.10.11+9de356786-nightly`, installed into a scratch `MOON_HOME`):

- nightly `core` really has no `strconv` — absent from `lib/core`, present in stable
- the workspace is **clean on nightly**: 0 errors on all three targets
- warnings are 474 `implicit_impl_as_method` (nightly deprecating implicit trait-impl promotion — this will need `pub extend T with Trait::{...}` eventually), 2 `unused_errdefer`, 1 `deprecated` (`Array::new()`). All pre-existing, none blocking.
- **the canary catches the regression**: re-adding `"moonbitlang/core/strconv"` to `rabbita/url/moon.pkg` and running this workflow's exact step script under `bash -e` exits non-zero with `Cannot find import 'moonbitlang/core/strconv'`, and aborts on the first failing target rather than running all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmoyPMELemz5hdNNdXyAkm