### PR TITLE
fix(ssr): restore host cleanup on error; release 0.15.6

### DIFF
--- a/rabbita/internal/runtime/host_ssr.mbt
+++ b/rabbita/internal/runtime/host_ssr.mbt
@@ -53,6 +53,7 @@ pub async fn SSRHost::SSRHost(
     }
     (host, ambient_host.protect(host, builder))
   })
+  errdefer host.cleanup()
   let cmd = Context::inject_url_changed(host, host.origin + host.path)
   Scheduler::queue_command(host, cmd)
 
@@ -65,7 +66,6 @@ pub async fn SSRHost::SSRHost(
   }
 
   host.document = Some(@vdom.VDom::initialize(vnode, host))
-  errdefer host.cleanup()
   host
 }
 

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/rabbita"
 
-version = "0.15.5"
+version = "0.15.6"
 
 readme = "README.md"
 

--- a/rabbita/top.mbt
+++ b/rabbita/top.mbt
@@ -96,10 +96,10 @@ pub async fn App::render(
     let output = (self.builder)()
     output.0.map(html => html.0)
   })
+  defer host.cleanup()
   let html = @async.with_timeout(timeout, () => {
     host.render_to_string(head.map(html => html.to_virtual_dom()))
   })
-  defer host.cleanup()
   html
 }
 


### PR DESCRIPTION
Found while trying to cut a release: **`rabbita` 0.15.5 was never published, and the publish workflow could not have published it.**

## The release path is broken

`publish.yml` gates on `moon check --target all --deny-warn`. That fails today:

```
Error: [0091] rabbita/internal/runtime/host_ssr.mbt:68:12
  errdefer host.cleanup()
  Error Warning (unused_errdefer): This `errdefer` is useless
```

`check.yml` never caught it because `stable-build` runs `--deny-warn` on **js only**, and this warning fires on **native and wasm**:

| `moon check --deny-warn` | result |
|---|---|
| `--target js` (what CI gates on) | pass |
| `--target native` | **fail** |
| `--target wasm` | **fail** |

## It is a real regression, not a lint

`423e881` ("refactor(rabbita): simplify SSR cleanup") replaced two `try { ... } catch { e => { host.cleanup(); raise e } }` blocks with `errdefer`/`defer` — but registered both *after* the work that can raise, so neither runs on the error path:

- **`host_ssr.mbt`** — `errdefer host.cleanup()` sat after `VDom::initialize`, the last fallible call. A raise while injecting the URL, draining the task queue, or initializing the document leaks the host's scope and stores. `SSRHost` doesn't return on that path, so the caller can't clean up either.
- **`top.mbt`** — `defer host.cleanup()` sat after `with_timeout`, so a render exceeding the 10s timeout skipped cleanup entirely. That is precisely the case `d8647db` ("fix(ssr): clean up host after render timeout") added cleanup for.

Both fixes move the registration ahead of the fallible work, restoring the pre-`423e881` semantics exactly: `errdefer` still fires only on the error path (where the host is not returned, so no double cleanup), and `defer` fires on both paths, as the old explicit `host.cleanup()` calls did.

## Verification

- `moon check --target all --deny-warn` now **passes** (was exit 255)
- `moon test`: **86 passed** native, **95 passed** js
- `moon info --target js` produces no `.mbti` drift — this is not an API change

Version bumped to **0.15.6**. Note that 0.15.5 is declared in `moon.mod` on `main` but is not on mooncakes.io (the registry has ≤ 0.15.4), so the `strconv` fix from #168 is not yet available to anyone depending on rabbita — this release carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmoyPMELemz5hdNNdXyAkm