### PR TITLE
fix(ssr): make the render timeout cover rendering

### DIFF
--- a/rabbita/top.mbt
+++ b/rabbita/top.mbt
@@ -92,15 +92,14 @@ pub async fn App::render(
   timeout? : Int = 10_000,
 ) -> String {
   let (origin, path) = split_url(url)
-  let host = @runtime.SSRHost(origin~, path~, () => {
-    let output = (self.builder)()
-    output.0.map(html => html.0)
-  })
-  defer host.cleanup()
-  let html = @async.with_timeout(timeout, () => {
+  @async.with_timeout(timeout, () => {
+    let host = @runtime.SSRHost(origin~, path~, () => {
+      let output = (self.builder)()
+      output.0.map(html => html.0)
+    })
+    defer host.cleanup()
     host.render_to_string(head.map(html => html.to_virtual_dom()))
   })
-  html
 }
 
 ///|


### PR DESCRIPTION
Fixes #173.

`App::render`'s `timeout` could never fire. All of SSR's async work — graph evaluation, `drain_task`, the HTTP fetches `create_resource` issues — happens inside `@runtime.SSRHost(...)`, on the line *before* `with_timeout`. What `with_timeout` wrapped was `render_to_string`, declared `pub fn` rather than `pub async fn`, so it has no suspension point and the timer can never preempt it.

This moves the `SSRHost` construction inside the timeout, where the awaiting actually is, and keeps `defer host.cleanup()` in the same closure so it still runs on both the success and the cancelled path.

```diff
 let (origin, path) = split_url(url)
-let host = @runtime.SSRHost(origin~, path~, () => {
-  let output = (self.builder)()
-  output.0.map(html => html.0)
-})
-defer host.cleanup()
-let html = @async.with_timeout(timeout, () => {
-  host.render_to_string(head.map(html => html.to_virtual_dom()))
-})
-html
+@async.with_timeout(timeout, () => {
+  let host = @runtime.SSRHost(origin~, path~, () => {
+    let output = (self.builder)()
+    output.0.map(html => html.0)
+  })
+  defer host.cleanup()
+  host.render_to_string(head.map(html => html.to_virtual_dom()))
+})
```

## Verification

Probe in #173 — render against an endpoint that sleeps 2s, with `timeout=100`:

| | result |
|---|---|
| `rabbita@0.15.6` | `RETURNED (no raise)` after ~2s, with the fetched data |
| this branch | `RAISED: TimeoutError` |

Cancellation does not leak the host: with `SSRHost::cleanup` instrumented with a `println`, the timeout path prints `[probe] SSRHost::cleanup ran` before the raise.

- `moon check --target native --deny-warn` — pass
- `moon check --target wasm --deny-warn` — pass
- `moon test --target native` — 86 passed, unchanged

## Two things I deliberately did not do

**No regression test.** `@cmd.perform` and `@cmd.effect` are `#cfg(target="js")`, so the native async-command surface is effectively HTTP and a test needs a live server. `moon test` is also commented out in `check.yml`, so it would not run in CI anyway. Rather than add a timing-sensitive test nobody runs, the reproduction is written out in full in #173 so it can be verified independently.

**No version bump.** Left at 0.15.6 so the bump can be made at release time rather than going stale while this is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmoyPMELemz5hdNNdXyAkm