### PR TITLE
feat: add HTML memoization and fix empty fragment moves

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,12 +16,24 @@ Each application uses Warren's minimized root-package layout. The fixtures are:
 - `apps/subscriptions` on port `4307`
 - `apps/dom-api` on port `4308`
 - `apps/rui` on port `4309`
+- `apps/memo` on port `4310`
 
 The suite covers stable public behavior: state and message composition, forms
 and DOM events, incremental collection lifecycles, same-origin navigation,
 commands and asynchronous work, mocked HTTP, and subscription lifecycles. It
 also exercises the public DOM bindings against real browser objects. It does
 not assert ordering for batched or nested messages.
+
+`apps/memo` verifies memo compute counts, independent caches, custom hashes,
+event updates, and transitions between ordinary, fragment, and nested memo
+nodes, including removal and remounting. It also covers keyed fragment moves,
+empty fragment boundaries, and independent invalidation of nested memo caches. Run it with
+`npm test -- --project=memo-chromium`.
+Its components use `create_variable` for state and expose MoonBit render counters
+through DOM snapshots. Each snapshot has a reading number so tests wait for a
+fresh result without accessing JavaScript globals or adding FFI probes.
+For manual checks, `Toggle keyed trailing marker` removes the final sibling so
+keyed fragments can also move directly to the end of their container.
 
 `apps/rui` is a single-page showcase of the RUI (`Yoorkin/rui`) component
 library. One Playwright project drives it and the `rui.*.spec.ts` files cover

--- a/e2e/apps/memo/app.mbt
+++ b/e2e/apps/memo/app.mbt
@@ -1,0 +1,39 @@
+///|
+using @rabbita {type Html, type Val, type Emit}
+
+///|
+using @html {button, div, h1, input, p, span}
+
+///|
+fn app() -> Val[Html] {
+  let (parent, set_parent) = @rabbita.create_variable(0)
+  let (value, set_value) = @rabbita.create_variable(1)
+  let (selected, set_selected) = @rabbita.create_variable(0)
+  let select = set_selected.map(value => _ => value)
+  let basic = basic_memo_component(parent, value, select)
+  let custom = custom_memo_component(parent, value, select)
+  let lifecycle = memo_lifecycle_component(parent, value, select)
+  let keyed = keyed_memo_component()
+  parent.view7(value, selected, basic, custom, lifecycle, keyed, (
+    parent,
+    value,
+    selected,
+    basic,
+    custom,
+    lifecycle,
+    keyed,
+  ) => {
+    div <| [
+      h1("Memo rendering"),
+      p(id="parent-version", "parent: \{parent}"),
+      p(id="input-value", "input: \{value}"),
+      p(id="selected-value", "selected: \{selected}"),
+      button(on_click=set_parent(value => value + 1), "Update parent"),
+      button(on_click=set_value(value => value + 1), "Update memo input"),
+      basic,
+      custom,
+      lifecycle,
+      keyed,
+    ]
+  })
+}

--- a/e2e/apps/memo/keyed_component.mbt
+++ b/e2e/apps/memo/keyed_component.mbt
@@ -1,0 +1,131 @@
+///|
+priv enum KeyedShape {
+  Element
+  Fragment
+  Empty
+  Text
+} derive(Eq, Hash)
+
+///|
+priv struct KeyedState {
+  reversed : Bool
+  shown : Bool
+  trailing_marker : Bool
+  shape : KeyedShape
+  value : Int
+} derive(Eq)
+
+///|
+fn keyed_memo_row(
+  key : String,
+  shape : KeyedShape,
+  value : Int,
+  select : Emit[String],
+  computes : RenderCounter,
+) -> Html {
+  @html.memo((key, shape, value), row => {
+    computes.value += 1
+    let (key, shape, value) = row
+    let children = [
+      span(id="keyed-\{key}-label", "\{key}:\{value}"),
+      input(id="keyed-\{key}-draft", placeholder="Keyed draft \{key}"),
+      button(
+        id="keyed-\{key}-pick",
+        on_click=select("\{key}:\{value}"),
+        "Pick keyed \{key} \{value}",
+      ),
+    ]
+    match shape {
+      Element => div(id="keyed-\{key}-element", children)
+      Fragment => @html.fragment(children)
+      Empty => @html.fragment([])
+      Text => @html.text("\{key} text \{value}")
+    }
+  })
+}
+
+///|
+fn keyed_memo_component() -> Val[Html] {
+  let (model, set_model) = @rabbita.create_variable(KeyedState::{
+    reversed: false,
+    shown: true,
+    trailing_marker: true,
+    shape: Fragment,
+    value: 1,
+  })
+  let (selected, set_selected) = @rabbita.create_variable("")
+  let select = set_selected.map(value => _ => value)
+  let (computes, compute_counter) = render_counter("keyed")
+  let move_as = set_model.map(shape => {
+    model => {
+      ..model,
+      reversed: !model.reversed,
+      shape,
+      value: model.value + 1,
+    }
+  })
+  let content = model.view(model => {
+    let rows : Map[String, Html] = {
+      "before": span(id="keyed-before", "before|"),
+    }
+    let order = if model.reversed { ["c", "b", "a"] } else { ["a", "b", "c"] }
+    for key in order {
+      if key != "a" {
+        rows[key] = keyed_memo_row(key, Fragment, 1, select, computes)
+      } else if model.shown {
+        rows[key] = keyed_memo_row(
+          key,
+          model.shape,
+          model.value,
+          select,
+          computes,
+        )
+      }
+    }
+    if model.trailing_marker {
+      rows["after"] = span(id="keyed-after", "|after")
+    }
+    div <| [
+      button(
+        on_click=set_model(model => { ..model, reversed: !model.reversed, }),
+        "Reverse keyed rows",
+      ),
+      button(on_click=move_as(Element), "Move keyed a as element"),
+      button(on_click=move_as(Fragment), "Move keyed a as fragment"),
+      button(on_click=move_as(Empty), "Move keyed a as empty"),
+      button(on_click=move_as(Text), "Move keyed a as text"),
+      button(
+        on_click=set_model(model => {
+          ..model,
+          shape: Empty,
+          value: model.value + 1,
+        }),
+        "Clear keyed a",
+      ),
+      button(
+        on_click=set_model(model => { ..model, shown: false, }),
+        "Remove keyed a",
+      ),
+      button(
+        on_click=set_model(model => { ..model, shown: true, }),
+        "Add keyed a",
+      ),
+      button(
+        on_click=set_model(model => { ..model, value: model.value + 1, }),
+        "Update keyed a",
+      ),
+      button(
+        on_click=set_model(model => {
+          ..model,
+          trailing_marker: !model.trailing_marker,
+        }),
+        "Toggle keyed trailing marker",
+      ),
+      div(id="keyed-stage", rows),
+    ]
+  })
+  let result = selected.view(value => p(id="keyed-selected", value))
+  content.map3(result, compute_counter, (content, result, compute_counter) => {
+    div([content, result, compute_counter])
+  })
+}

--- a/e2e/apps/memo/lifecycle_component.mbt
+++ b/e2e/apps/memo/lifecycle_component.mbt
@@ -1,0 +1,116 @@
+///|
+priv enum Shape {
+  PlainElement
+  PlainText
+  PlainFragment
+  MemoElement
+  MemoText
+  MemoFragment
+  NestedMemo
+} derive(Eq, Hash)
+
+///|
+fn memo_shape(
+  shape : Shape,
+  value : Int,
+  revision : Int,
+  select : Emit[Int],
+  computes : RenderCounter,
+  nested_computes : RenderCounter,
+) -> Html {
+  match shape {
+    PlainElement => div(id="plain-element", "plain element \{value}")
+    PlainText => @html.text("plain text \{value}")
+    PlainFragment =>
+      @html.fragment([
+        span(id="plain-first", "plain first \{value}"),
+        span(id="plain-second", "plain second \{value}"),
+      ])
+    MemoElement | MemoText | MemoFragment | NestedMemo =>
+      @html.memo((shape, value, revision), input => {
+        computes.value += 1
+        let (shape, value, _) = input
+        match shape {
+          MemoText => @html.text("memo text \{value}")
+          MemoFragment =>
+            @html.fragment([
+              span(id="memo-first", "memo first \{value}"),
+              button(
+                id="memo-second",
+                on_click=select(value),
+                "Choose fragment value \{value}",
+              ),
+            ])
+          NestedMemo =>
+            @html.memo(value, value => {
+              nested_computes.value += 1
+              @html.fragment([
+                span(id="nested-first", "nested first \{value}"),
+                button(
+                  id="nested-second",
+                  on_click=select(value),
+                  "Choose nested value \{value}",
+                ),
+              ])
+            })
+          _ => div(id="memo-element", "memo element \{value}")
+        }
+      })
+  }
+}
+
+///|
+fn memo_lifecycle_component(
+  parent : Val[Int],
+  value : Val[Int],
+  select : Emit[Int],
+) -> Val[Html] {
+  let (shape, set_shape) = @rabbita.create_variable(MemoElement)
+  let (shown, set_shown) = @rabbita.create_variable(true)
+  let (revision, set_revision) = @rabbita.create_variable(0)
+  let (views, view_counter) = render_counter("lifecycle_view")
+  let (computes, compute_counter) = render_counter("shape")
+  let (nested_computes, nested_counter) = render_counter("nested")
+  let content = parent.view5(value, shape, shown, revision, (
+    _,
+    value,
+    shape,
+    shown,
+    revision,
+  ) => {
+    views.value += 1
+    div <| [
+      div <| [
+        button(on_click=set_shape(_ => PlainElement), "Plain element"),
+        button(on_click=set_shape(_ => PlainText), "Plain text"),
+        button(on_click=set_shape(_ => PlainFragment), "Plain fragment"),
+        button(on_click=set_shape(_ => MemoElement), "Memo element"),
+        button(on_click=set_shape(_ => MemoText), "Memo text"),
+        button(on_click=set_shape(_ => MemoFragment), "Memo fragment"),
+        button(on_click=set_shape(_ => NestedMemo), "Nested memo"),
+        button(on_click=set_shown(_ => false), "Hide memo shape"),
+        button(on_click=set_shown(_ => true), "Show memo shape"),
+        button(
+          on_click=set_revision(value => value + 1),
+          "Invalidate outer memo",
+        ),
+      ],
+      p(id="outer-revision", "outer revision: \{revision}"),
+      div(id="transition-stage") <| [
+        span(id="before-shape", "before"),
+        if shown {
+          memo_shape(shape, value, revision, select, computes, nested_computes)
+        } else {
+          @html.nothing
+        },
+        span(id="after-shape", "after"),
+      ],
+    ]
+  })
+  content.map4(view_counter, compute_counter, nested_counter, (
+    content,
+    view_counter,
+    compute_counter,
+    nested_counter,
+  ) => div([content, view_counter, compute_counter, nested_counter]))
+}

--- a/e2e/apps/memo/main.mbt
+++ b/e2e/apps/memo/main.mbt
@@ -1,0 +1,4 @@
+///|
+fn main {
+  @rabbita.new(app).mount("app")
+}

--- a/e2e/apps/memo/memo_components.mbt
+++ b/e2e/apps/memo/memo_components.mbt
@@ -1,0 +1,77 @@
+///|
+fn basic_memo_component(
+  parent : Val[Int],
+  value : Val[Int],
+  select : Emit[Int],
+) -> Val[Html] {
+  let (views, view_counter) = render_counter("basic_view")
+  let (computes, compute_counter) = render_counter("basic")
+  let (sibling_computes, sibling_counter) = render_counter("sibling")
+  // Keep parent as a dependency so these updates exercise VDOM memoization,
+  // rather than being skipped by the component's incremental view.
+  let content = parent.view2(value, (_, value) => {
+    views.value += 1
+    @html.fragment([
+      @html.memo(value, value => {
+        computes.value += 1
+        div(id="basic-memo") <| [
+          p(id="basic-value", "memo value: \{value}"),
+          input(placeholder="Memo draft"),
+          button(on_click=select(value), "Choose memo value"),
+        ]
+      }),
+      // Equal inputs in different positions must retain independent caches.
+      @html.memo(value, value => {
+        sibling_computes.value += 1
+        p(id="sibling-value", "sibling value: \{value}")
+      }),
+    ])
+  })
+  content.map4(view_counter, compute_counter, sibling_counter, (
+    content,
+    view_counter,
+    compute_counter,
+    sibling_counter,
+  ) => div([content, view_counter, compute_counter, sibling_counter]))
+}
+
+///|
+// This deliberately has no Hash implementation: memo_by accepts arbitrary input.
+priv struct CustomInput {
+  value : Int
+  _ignored : Int
+}
+
+///|
+fn custom_memo_component(
+  parent : Val[Int],
+  value : Val[Int],
+  select : Emit[Int],
+) -> Val[Html] {
+  let (ignored, set_ignored) = @rabbita.create_variable(0)
+  let (views, view_counter) = render_counter("custom_view")
+  let (computes, compute_counter) = render_counter("custom")
+  let content = parent.view3(value, ignored, (_, value, ignored) => {
+    views.value += 1
+    div <| [
+      p(id="ignored-version", "ignored: \{ignored}"),
+      button(on_click=set_ignored(value => value + 1), "Update ignored field"),
+      @html.memo_by(
+        CustomInput::{ value, _ignored: ignored, },
+        input => {
+          computes.value += 1
+          div(id="custom-memo") <| [
+            p(id="custom-value", "custom value: \{input.value}"),
+            button(on_click=select(input.value), "Choose custom value"),
+          ]
+        },
+        by=input => input.value,
+      ),
+    ]
+  })
+  content.map3(view_counter, compute_counter, (
+    content,
+    view_counter,
+    compute_counter,
+  ) => div([content, view_counter, compute_counter]))
+}

--- a/e2e/apps/memo/moon.mod
+++ b/e2e/apps/memo/moon.mod
@@ -1,0 +1,13 @@
+name = "local/rabbita-e2e-memo"
+
+version = "0.1.0"
+
+import {
+  "moonbit-community/rabbita@0.15.7",
+}
+
+license = "Apache-2.0"
+
+description = "Memo rendering and lifecycle fixtures for Rabbita end-to-end tests."
+
+preferred_target = "js"

--- a/e2e/apps/memo/moon.pkg
+++ b/e2e/apps/memo/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+}
+
+supported_targets = "js"
+
+pkgtype(kind: "executable")

--- a/e2e/apps/memo/pkg.generated.mbti
+++ b/e2e/apps/memo/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "local/rabbita-e2e-memo"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/e2e/apps/memo/render_counter.mbt
+++ b/e2e/apps/memo/render_counter.mbt
@@ -1,0 +1,35 @@
+///|
+priv struct RenderCounter {
+  mut value : Int
+}
+
+///|
+priv struct CounterSnapshot {
+  reading : Int
+  value : Int
+} derive(Eq)
+
+///|
+// Expose a snapshot through an independent view so reading the count does not
+// rerun the measured component.
+fn render_counter(name : String) -> (RenderCounter, Val[Html]) {
+  let counter = RenderCounter::{ value: 0, }
+  let (snapshot, set_snapshot) = @rabbita.create_variable({
+    reading: 0,
+    value: 0,
+  })
+  let view = snapshot.view(snapshot => {
+    div <| [
+      button(
+        on_click=set_snapshot(snapshot => {
+          reading: snapshot.reading + 1,
+          value: counter.value,
+        }),
+        "Read \{name} count",
+      ),
+      p(id="count-\{name}", "\{snapshot.value}"),
+      p(id="count-\{name}-reading", "\{snapshot.reading}"),
+    ]
+  })
+  (counter, view)
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -12,6 +12,7 @@ const apps = [
   { name: 'subscriptions', port: 4307 },
   { name: 'dom-api', port: 4308 },
   { name: 'rui', port: 4309 },
+  { name: 'memo', port: 4310 },
 ] as const;
 const appUrl = (port: number) => `http://127.0.0.1:${port}`;
 

--- a/e2e/tests/memo.keyed.spec.ts
+++ b/e2e/tests/memo.keyed.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type Shape = 'fragment' | 'element' | 'empty' | 'text';
+
+async function expectKeyedCount(page: Page, expected: number) {
+  const reading = page.locator('#count-keyed-reading');
+  const previous = Number(await reading.innerText());
+  await page.getByRole('button', { name: 'Read keyed count', exact: true }).click();
+  await expect(reading).toHaveText(String(previous + 1));
+  await expect(page.locator('#count-keyed')).toHaveText(String(expected));
+}
+
+async function expectRows(page: Page, order: string[], shape: Shape = 'fragment', value = 1) {
+  const ids = ['keyed-before'];
+  let text = 'before|';
+  for (const key of order) {
+    const rowShape = key === 'a' ? shape : 'fragment';
+    const rowValue = key === 'a' ? value : 1;
+    if (rowShape === 'empty') continue;
+    if (rowShape === 'text') {
+      text += `${key} text ${rowValue}`;
+      continue;
+    }
+    text += `${key}:${rowValue}Pick keyed ${key} ${rowValue}`;
+    ids.push(...(rowShape === 'element'
+      ? [`keyed-${key}-element`]
+      : [`keyed-${key}-label`, `keyed-${key}-draft`, `keyed-${key}-pick`]));
+  }
+  ids.push('keyed-after');
+  const stage = page.locator('#keyed-stage');
+  await expect(stage).toHaveText(`${text}|after`);
+  await expect.poll(() => stage.locator(':scope > [id]').evaluateAll(
+    (nodes) => nodes.map(({ id }) => id),
+  )).toEqual(ids);
+}
+
+async function expectFragmentBoundaries(page: Page, count: number) {
+  await expect.poll(() => page.locator('#keyed-stage').evaluate((stage) =>
+    Array.from(stage.childNodes)
+      .filter((node) => node.nodeType === Node.COMMENT_NODE)
+      .map((node) => node.nodeValue),
+  )).toEqual(Array.from({ length: count }, () => ['[', ']']).flat());
+}
+
+test('keyed memo fragments retain nodes and drafts during moves and remount after deletion', async ({ page }) => {
+  await page.goto('/');
+  await expectRows(page, ['a', 'b', 'c']);
+  const draft = page.getByPlaceholder('Keyed draft a');
+  await draft.fill('draft a');
+  const original = await draft.elementHandle();
+  const sibling = page.getByPlaceholder('Keyed draft b');
+  await sibling.fill('draft b');
+  const originalSibling = await sibling.elementHandle();
+  await expectKeyedCount(page, 3);
+
+  for (const order of [['c', 'b', 'a'], ['a', 'b', 'c']]) {
+    await page.getByRole('button', { name: 'Reverse keyed rows', exact: true }).click();
+    await expectRows(page, order);
+    await expectFragmentBoundaries(page, 3);
+    await expect(draft).toHaveValue('draft a');
+    expect(await draft.evaluate((node, original) => node === original, original)).toBe(true);
+    await expectKeyedCount(page, 3);
+  }
+
+  await page.getByRole('button', { name: 'Remove keyed a', exact: true }).click();
+  await expectRows(page, ['b', 'c']);
+  expect(await original!.evaluate((node) => node.isConnected)).toBe(false);
+  await page.getByRole('button', { name: 'Add keyed a', exact: true }).click();
+  await expectRows(page, ['a', 'b', 'c']);
+  await expect(draft).toHaveValue('');
+  await expectKeyedCount(page, 4);
+  await page.getByRole('button', { name: 'Pick keyed a 1', exact: true }).click();
+  await expect(page.locator('#keyed-selected')).toHaveText('a:1');
+  await page.getByRole('button', { name: 'Update keyed a', exact: true }).click();
+  await expectRows(page, ['a', 'b', 'c'], 'fragment', 2);
+  await page.getByRole('button', { name: 'Pick keyed a 2', exact: true }).click();
+  await expect(page.locator('#keyed-selected')).toHaveText('a:2');
+  await expectKeyedCount(page, 5);
+  await expect(sibling).toHaveValue('draft b');
+  expect(await sibling.evaluate((node, original) => node === original, originalSibling)).toBe(true);
+});
+
+test('keyed memo can move and change between element, fragment, empty, and text in one update', async ({ page }) => {
+  await page.goto('/');
+  await expectRows(page, ['a', 'b', 'c']);
+  const shapes: Shape[] = ['element', 'fragment', 'empty', 'text', 'element'];
+  for (const [index, shape] of shapes.entries()) {
+    await page.getByRole('button', { name: `Move keyed a as ${shape}`, exact: true }).click();
+    await expectRows(page, index % 2 === 0 ? ['c', 'b', 'a'] : ['a', 'b', 'c'], shape, index + 2);
+    await expectFragmentBoundaries(page, shape === 'fragment' || shape === 'empty' ? 3 : 2);
+    await expectKeyedCount(page, index + 4);
+  }
+  await page.getByRole('button', { name: 'Pick keyed a 6', exact: true }).click();
+  await expect(page.locator('#keyed-selected')).toHaveText('a:6');
+});
+
+test('empty keyed memo keeps its start and end boundaries through moves, expansion, and removal', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Clear keyed a', exact: true }).click();
+  await expectRows(page, ['a', 'b', 'c'], 'empty');
+  await expectFragmentBoundaries(page, 3);
+
+  for (const order of [['c', 'b', 'a'], ['a', 'b', 'c']]) {
+    await page.getByRole('button', { name: 'Reverse keyed rows', exact: true }).click();
+    await expectRows(page, order, 'empty');
+    await expectFragmentBoundaries(page, 3);
+  }
+
+  await page.getByRole('button', { name: 'Move keyed a as fragment', exact: true }).click();
+  await expectRows(page, ['c', 'b', 'a'], 'fragment', 3);
+  await expectFragmentBoundaries(page, 3);
+  await page.getByRole('button', { name: 'Clear keyed a', exact: true }).click();
+  await expectRows(page, ['c', 'b', 'a'], 'empty');
+  await page.getByRole('button', { name: 'Reverse keyed rows', exact: true }).click();
+  await expectRows(page, ['a', 'b', 'c'], 'empty');
+  await expectFragmentBoundaries(page, 3);
+  await page.getByRole('button', { name: 'Remove keyed a', exact: true }).click();
+  await expectRows(page, ['b', 'c']);
+  await expectFragmentBoundaries(page, 2);
+});

--- a/e2e/tests/memo.spec.ts
+++ b/e2e/tests/memo.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function expectCount(page: Page, name: string, expected: number) {
+  const reading = page.locator(`#count-${name}-reading`);
+  const previousReading = Number(await reading.innerText());
+  await page.getByRole('button', { name: `Read ${name} count`, exact: true }).click();
+  await expect(reading).toHaveText(String(previousReading + 1));
+  await expect(page.locator(`#count-${name}`)).toHaveText(String(expected));
+}
+
+async function expectShape(page: Page, text: string, ids: string[]) {
+  const stage = page.locator('#transition-stage');
+  await expect(stage).toHaveText(`before${text}after`);
+  await expect
+    .poll(() => stage.locator(':scope > [id]').evaluateAll((nodes) => nodes.map(({ id }) => id)))
+    .toEqual(['before-shape', ...ids, 'after-shape']);
+}
+
+test('memo skips unchanged input and keeps same-hash sibling caches independent', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#basic-value')).toHaveText('memo value: 1');
+  await expect(page.locator('#sibling-value')).toHaveText('sibling value: 1');
+  await expectCount(page, 'basic', 1);
+  await expectCount(page, 'sibling', 1);
+  await expectCount(page, 'basic_view', 1);
+
+  const draft = page.getByPlaceholder('Memo draft');
+  await draft.fill('keep this draft');
+  const original = await draft.elementHandle();
+  for (let parent = 1; parent <= 3; parent += 1) {
+    await page.getByRole('button', { name: 'Update parent', exact: true }).click();
+    await expect(page.locator('#parent-version')).toHaveText(`parent: ${parent}`);
+    await expectCount(page, 'basic_view', parent + 1);
+    await expectCount(page, 'basic', 1);
+    await expectCount(page, 'sibling', 1);
+  }
+
+  await expect(draft).toHaveValue('keep this draft');
+  expect(await draft.evaluate((node, original) => node === original, original)).toBe(true);
+  await expect(page.locator('#sibling-value')).toHaveText('sibling value: 1');
+
+  await page.getByRole('button', { name: 'Update memo input', exact: true }).click();
+  await expect(page.locator('#basic-value')).toHaveText('memo value: 2');
+  await expect(page.locator('#sibling-value')).toHaveText('sibling value: 2');
+  await expectCount(page, 'basic', 2);
+  await expectCount(page, 'sibling', 2);
+});
+
+test('memo updates DOM and event closures when its input changes', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Choose memo value', exact: true }).click();
+  await expect(page.locator('#selected-value')).toHaveText('selected: 1');
+  await expectCount(page, 'basic', 1);
+
+  await page.getByRole('button', { name: 'Update memo input', exact: true }).click();
+  await expect(page.locator('#basic-value')).toHaveText('memo value: 2');
+  await expectCount(page, 'basic', 2);
+  await page.getByRole('button', { name: 'Choose memo value', exact: true }).click();
+  await expect(page.locator('#selected-value')).toHaveText('selected: 2');
+  await expectCount(page, 'basic', 2);
+});
+
+test('memo_by supports an input without Hash and invalidates only with the custom hash', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#custom-value')).toHaveText('custom value: 1');
+  await expectCount(page, 'custom', 1);
+  await expectCount(page, 'custom_view', 1);
+
+  await page.getByRole('button', { name: 'Update ignored field', exact: true }).click();
+  await expect(page.locator('#ignored-version')).toHaveText('ignored: 1');
+  await expectCount(page, 'custom_view', 2);
+  await expect(page.locator('#custom-value')).toHaveText('custom value: 1');
+  await expectCount(page, 'custom', 1);
+  await page.getByRole('button', { name: 'Choose custom value', exact: true }).click();
+  await expect(page.locator('#selected-value')).toHaveText('selected: 1');
+
+  await page.getByRole('button', { name: 'Update memo input', exact: true }).click();
+  await expect(page.locator('#custom-value')).toHaveText('custom value: 2');
+  await expectCount(page, 'custom', 2);
+  await page.getByRole('button', { name: 'Choose custom value', exact: true }).click();
+  await expect(page.locator('#selected-value')).toHaveText('selected: 2');
+  await expectCount(page, 'custom', 2);
+});
+
+test('memo and ordinary elements, text, and fragments replace each other without disturbing siblings', async ({ page }) => {
+  await page.goto('/');
+  await expectShape(page, 'memo element 1', ['memo-element']);
+
+  const shapes = [
+    { button: 'Plain element', text: 'plain element 1', ids: ['plain-element'] },
+    { button: 'Memo element', text: 'memo element 1', ids: ['memo-element'] },
+    { button: 'Plain text', text: 'plain text 1', ids: [] },
+    { button: 'Memo text', text: 'memo text 1', ids: [] },
+    { button: 'Plain fragment', text: 'plain first 1plain second 1', ids: ['plain-first', 'plain-second'] },
+    { button: 'Memo fragment', text: 'memo first 1Choose fragment value 1', ids: ['memo-first', 'memo-second'] },
+    { button: 'Plain element', text: 'plain element 1', ids: ['plain-element'] },
+  ];
+  for (const shape of shapes) {
+    await page.getByRole('button', { name: shape.button, exact: true }).click();
+    await expectShape(page, shape.text, shape.ids);
+  }
+  await expectCount(page, 'shape', 4);
+});
+
+test('memo results can change node kind and nest another memo with current event handlers', async ({ page }) => {
+  await page.goto('/');
+  await expectShape(page, 'memo element 1', ['memo-element']);
+  await page.getByRole('button', { name: 'Memo text', exact: true }).click();
+  await expectShape(page, 'memo text 1', []);
+  await page.getByRole('button', { name: 'Memo fragment', exact: true }).click();
+  await expectShape(page, 'memo first 1Choose fragment value 1', ['memo-first', 'memo-second']);
+  await page.getByRole('button', { name: 'Nested memo', exact: true }).click();
+  await expectShape(page, 'nested first 1Choose nested value 1', ['nested-first', 'nested-second']);
+  await expectCount(page, 'shape', 4);
+  await expectCount(page, 'nested', 1);
+  await expectCount(page, 'lifecycle_view', 4);
+
+  await page.getByRole('button', { name: 'Update parent', exact: true }).click();
+  await expect(page.locator('#parent-version')).toHaveText('parent: 1');
+  await expectCount(page, 'lifecycle_view', 5);
+  await expectCount(page, 'shape', 4);
+  await expectCount(page, 'nested', 1);
+
+  await page.getByRole('button', { name: 'Update memo input', exact: true }).click();
+  await expectShape(page, 'nested first 2Choose nested value 2', ['nested-first', 'nested-second']);
+  await expectCount(page, 'shape', 5);
+  await expectCount(page, 'nested', 2);
+  await page.getByRole('button', { name: 'Choose nested value 2', exact: true }).click();
+  await expect(page.locator('#selected-value')).toHaveText('selected: 2');
+  await expectCount(page, 'shape', 5);
+  await expectCount(page, 'nested', 2);
+
+  await page.getByRole('button', { name: 'Memo element', exact: true }).click();
+  await expectShape(page, 'memo element 2', ['memo-element']);
+  await expectCount(page, 'shape', 6);
+});
+
+test('invalidating an outer memo retains the inner memo cache until its own input changes', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Nested memo', exact: true }).click();
+  await expectShape(page, 'nested first 1Choose nested value 1', ['nested-first', 'nested-second']);
+  const original = await page.locator('#nested-first').elementHandle();
+  await expectCount(page, 'shape', 2);
+  await expectCount(page, 'nested', 1);
+
+  for (let revision = 1; revision <= 2; revision += 1) {
+    await page.getByRole('button', { name: 'Invalidate outer memo', exact: true }).click();
+    await expect(page.locator('#outer-revision')).toHaveText(`outer revision: ${revision}`);
+    await expectCount(page, 'shape', 2 + revision);
+    await expectCount(page, 'nested', 1);
+  }
+  expect(await page.locator('#nested-first').evaluate((node, original) => node === original, original)).toBe(true);
+
+  await page.getByRole('button', { name: 'Update memo input', exact: true }).click();
+  await expectShape(page, 'nested first 2Choose nested value 2', ['nested-first', 'nested-second']);
+  await expectCount(page, 'shape', 5);
+  await expectCount(page, 'nested', 2);
+  await page.getByRole('button', { name: 'Choose nested value 2', exact: true }).click();
+  await expect(page.locator('#selected-value')).toHaveText('selected: 2');
+});
+
+for (const shape of [
+  { button: 'Memo fragment', prefix: 'memo', label: 'fragment' },
+  { button: 'Nested memo', prefix: 'nested', label: 'nested' },
+]) {
+  test(`${shape.button} removes its entire DOM range and recomputes after remounting`, async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: shape.button, exact: true }).click();
+    const text = (value: number) => `${shape.prefix} first ${value}Choose ${shape.label} value ${value}`;
+    const ids = [`${shape.prefix}-first`, `${shape.prefix}-second`];
+    await expectShape(page, text(1), ids);
+    const original = await page.locator(`#${shape.prefix}-first`).elementHandle();
+    await expectCount(page, 'shape', 2);
+
+    await page.getByRole('button', { name: 'Hide memo shape', exact: true }).click();
+    await expectShape(page, '', []);
+    expect(await original!.evaluate((node) => node.isConnected)).toBe(false);
+    await page.getByRole('button', { name: 'Update parent', exact: true }).click();
+    await expect(page.locator('#parent-version')).toHaveText('parent: 1');
+    await expectCount(page, 'shape', 2);
+
+    await page.getByRole('button', { name: 'Show memo shape', exact: true }).click();
+    await expectShape(page, text(1), ids);
+    await expectCount(page, 'shape', 3);
+    if (shape.label === 'nested') {
+      await expectCount(page, 'nested', 2);
+    }
+
+    await page.getByRole('button', { name: 'Hide memo shape', exact: true }).click();
+    await expectShape(page, '', []);
+    await page.getByRole('button', { name: 'Update memo input', exact: true }).click();
+    await expect(page.locator('#input-value')).toHaveText('input: 2');
+    await expectCount(page, 'shape', 3);
+    await page.getByRole('button', { name: 'Show memo shape', exact: true }).click();
+    await expectShape(page, text(2), ids);
+    await expectCount(page, 'shape', 4);
+    await page.getByRole('button', { name: `Choose ${shape.label} value 2`, exact: true }).click();
+    await expect(page.locator('#selected-value')).toHaveText('selected: 2');
+  });
+}

--- a/moon.work
+++ b/moon.work
@@ -25,4 +25,5 @@ members = [
   "e2e/apps/subscriptions",
   "e2e/apps/dom-api",
   "e2e/apps/rui",
+  "./e2e/apps/memo",
 ]

--- a/rabbita/html/html.mbt
+++ b/rabbita/html/html.mbt
@@ -2983,3 +2983,30 @@ pub fn[C : IsChildren] geolocation(
   push_id(id, attrs)
   VNode::elem("geolocation", attrs.to_props(), children)
 }
+
+///|
+/// Lazily render `value`, reusing the previously mounted subtree at this
+/// position while `Hash::hash(value)` stays the same.
+///
+/// The hash is the entire cache key: values are not compared for equality and
+/// changes to `compute` are not detected. Equal hashes must imply equivalent
+/// HTML and event handlers. Include every changing render dependency in `value`;
+/// a hash collision can otherwise leave stale content or handlers on screen.
+///
+/// In a full document, use this inside `head` or `body`; the structural `html`,
+/// `head`, and `body` nodes themselves must remain unwrapped.
+pub fn[T : Hash] memo(value : T, compute : (T) -> Html) -> Html {
+  VNode::thunk(Hash::hash(value), () => compute(value).0)
+}
+
+///|
+/// Like `memo`, but uses `by(value)` as the entire cache key and does not
+/// require `T` to implement `Hash`.
+///
+/// Equal keys must imply equivalent HTML and event handlers, including any
+/// state captured by `compute`. Changing only `compute` does not invalidate the
+/// cache. The subtree is computed again after removal and remounting.
+/// As with `memo`, do not wrap the structural `html`, `head`, or `body` nodes.
+pub fn[T] memo_by(value : T, compute : (T) -> Html, by~ : (T) -> Int) -> Html {
+  VNode::thunk(by(value), () => compute(value).0)
+}

--- a/rabbita/html/pkg.generated.mbti
+++ b/rabbita/html/pkg.generated.mbti
@@ -143,6 +143,10 @@ pub fn[C : IsChildren] mark(style? : Array[String], id? : String, class? : Strin
 
 pub fn[C : IsChildren] math(style? : Array[String], id? : String, class? : String, title? : String, hidden? : Bool, attrs? : Attrs, C) -> Html
 
+pub fn[T : Hash] memo(T, (T) -> Html) -> Html
+
+pub fn[T] memo_by(T, (T) -> Html, by~ : (T) -> Int) -> Html
+
 pub fn[C : IsChildren] menu(style? : Array[String], id? : String, class? : String, title? : String, hidden? : Bool, attrs? : Attrs, C) -> Html
 
 pub fn meta(style? : Array[String], id? : String, class? : String, title? : String, hidden? : Bool, charset? : String, name? : String, content? : String, http_equiv? : String, attrs? : Attrs) -> Html

--- a/rabbita/internal/vdom/diff.mbt
+++ b/rabbita/internal/vdom/diff.mbt
@@ -107,8 +107,9 @@ fn INode::relocate(
         parent.insert_before(node, anchor)
         anchor = nullable(node)
       }
-      parent.insert_before(end, before)
+      // For an empty fragment, anchor equals before: keep start before end.
       parent.insert_before(start, anchor)
+      parent.insert_before(end, before)
     }
   }
 }

--- a/rabbita/internal/vdom/pkg.generated.mbti
+++ b/rabbita/internal/vdom/pkg.generated.mbti
@@ -45,6 +45,7 @@ pub fn VNode::elem(String, Props, Children[Self], namespace_uri? : String) -> Se
 pub fn VNode::fragment(Array[Self]) -> Self
 pub fn VNode::link(Props, Children[Self], escape? : Bool) -> Self
 pub fn VNode::text(String) -> Self
+pub fn VNode::thunk(Int, () -> Self) -> Self
 pub impl Eq for VNode
 
 // Type aliases

--- a/rabbita/internal/vdom/vdom.mbt
+++ b/rabbita/internal/vdom/vdom.mbt
@@ -61,6 +61,11 @@ fn is_html_void_element(tag : String) -> Bool {
 }
 
 ///|
+pub fn VNode::thunk(hash : Int, f : () -> VNode) -> VNode {
+  VNode::Thunk(hash, f)
+}
+
+///|
 pub fn VNode::elem(
   tag : String,
   props : Props,

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/rabbita"
 
-version = "0.15.6"
+version = "0.15.7"
 
 readme = "README.md"
 


### PR DESCRIPTION
Adds `html.memo` and generic `html.memo_by(..., by=...)` to lazily render and reuse mounted subtrees by hash. Documents the cache-key requirements and document-root restrictions, and bumps Rabbita to 0.15.7.

Fixes fragment relocation when a memo returns an empty fragment: keyed reordering previously reversed the start/end markers, which could break later expansion or removal. Moving the start marker before the end marker preserves both empty and nonempty ranges.

Adds a dedicated component-based browser fixture with MoonBit counters read through DOM snapshots, without JS FFI probes. Coverage includes cache hits, independent and nested caches, current event handlers, node-type changes, keyed moves, and removal/remounting.

Validation:
- `moon check --target all`
- HTML/VDOM unit tests: 11 passed
- Memo and collections-lifecycle Chromium e2e: 14 passed
- Empty-fragment regression confirmed failing before the fix and passing afterward
- Manual visible-browser checks of both move directions, `before = null`, preserved drafts, node-type changes, and updated events
- `moon fmt`, `moon info`, and `git diff --check`
