### PR TITLE
perf: skip diffing physically equal VNodes

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -35,6 +35,13 @@ fresh result without accessing JavaScript globals or adding FFI probes.
 For manual checks, `Toggle keyed trailing marker` removes the final sibling so
 keyed fragments can also move directly to the end of their container.
 
+The `memo.physical-*.spec.ts` cases cover shared VNode references for elements,
+text, fragments, and thunks, including `A → A → B → B → A` updates, equal content
+with different references, tag/namespace changes, keyed moves, and remounting.
+They also check container roots and hydration against pre-rendered HTML with
+existing or missing fragment markers. Element style-read probes distinguish a
+skipped diff from a diff that leaves the DOM unchanged.
+
 `apps/rui` is a single-page showcase of the RUI (`Yoorkin/rui`) component
 library. One Playwright project drives it and the `rui.*.spec.ts` files cover
 representative user-visible behavior per component: disclosure open/close,

--- a/e2e/apps/counter/main.mbt
+++ b/e2e/apps/counter/main.mbt
@@ -18,13 +18,14 @@ fn app() -> Val[Html] {
       Decrement => count - 1
     }
   })
+  let actions = div(class="actions") <| [
+    button(on_click=emit(Decrement), "-"),
+    button(on_click=emit(Increment), "+"),
+  ]
   count.view(count => {
     div(class="app") <| [
       h1("\{count}"),
-      div(class="actions") <| [
-        button(on_click=emit(Decrement), "-"),
-        button(on_click=emit(Increment), "+"),
-      ],
+      actions,
     ]
   })
 }

--- a/e2e/apps/memo/main.mbt
+++ b/e2e/apps/memo/main.mbt
@@ -1,4 +1,15 @@
 ///|
 fn main {
-  @rabbita.new(app).mount("app")
+  let url = @dom.window().current_url()
+  if url.contains("physical-document") {
+    @rabbita.new(physical_document_app).hydrate()
+  } else if url.contains("physical-root") {
+    @rabbita.new(physical_root_app).mount("app")
+  } else if url.contains("physical-nodes") {
+    @rabbita.new(physical_nodes_app).mount("app")
+  } else if url.contains("physical-keyed") {
+    @rabbita.new(physical_keyed_app).mount("app")
+  } else {
+    @rabbita.new(app).mount("app")
+  }
 }

--- a/e2e/apps/memo/moon.pkg
+++ b/e2e/apps/memo/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/dom",
+  "moonbit-community/rabbita/svg",
 }
 
 supported_targets = "js"

--- a/e2e/apps/memo/physical_document.mbt
+++ b/e2e/apps/memo/physical_document.mbt
@@ -1,0 +1,47 @@
+///|
+fn physical_root_app() -> Val[Html] {
+  let (revision, advance) = @rabbita.create_variable(0)
+  let next = advance(revision => revision + 1)
+  let a = div(id="physical-root") <| [
+    p(id="physical-root-value", "A"),
+    button(on_click=next, "Advance root"),
+  ]
+  let b = div(id="physical-root") <| [
+    p(id="physical-root-value", "B"),
+    button(on_click=next, "Advance root"),
+  ]
+  revision.view(revision => if revision == 2 || revision == 3 { b } else { a })
+}
+
+///|
+fn physical_document_app() -> Val[Html] {
+  let (revision, advance) = @rabbita.create_variable(0)
+  let refresh = button(on_click=@rabbita.none, "Refresh document")
+  let update = button(
+    on_click=advance(revision => revision + 1),
+    "Update document",
+  )
+  let a = div(id="hydrated-element", "element A")
+  let b = div(id="hydrated-element", "element B")
+  let text = @html.text("shared text")
+  let fragment = @html.fragment([span(id="hydrated-fragment", "fragment")])
+  let thunk = @html.memo(0, _ => div(id="hydrated-thunk", "thunk"))
+  revision.view(revision => {
+    @html.html(id="physical-hydrated", [
+      @html.head([@html.title("Physical document \{revision}")]),
+      @html.body([
+        refresh,
+        update,
+        p(id="document-version", "revision: \{revision}"),
+        if revision == 2 || revision == 3 {
+          b
+        } else {
+          a
+        },
+        text,
+        fragment,
+        thunk,
+      ]),
+    ])
+  })
+}

--- a/e2e/apps/memo/physical_keyed.mbt
+++ b/e2e/apps/memo/physical_keyed.mbt
@@ -1,0 +1,77 @@
+///|
+priv struct PhysicalKeyedState {
+  tick : Int
+  reversed : Bool
+  shown : Bool
+  trailing : Bool
+} derive(Eq)
+
+///|
+fn physical_keyed_app() -> Val[Html] {
+  let (state, update) = @rabbita.create_variable(PhysicalKeyedState::{
+    tick: 0,
+    reversed: false,
+    shown: true,
+    trailing: true,
+  })
+  let (computes, counter) = render_counter("shared_keyed")
+  let shared_input = input(
+    class="shared-alias",
+    placeholder="Shared alias draft",
+  )
+  // Keep the same Html objects across ordering, removal, and remounting.
+  let shared : Map[String, Html] = {
+    "element": div(id="shared-element", [input(placeholder="Element draft")]),
+    "text": @html.text("shared text"),
+    "fragment": @html.fragment([
+      span(id="shared-fragment", "fragment"),
+      input(placeholder="Fragment draft"),
+    ]),
+    "empty": @html.fragment([]),
+    "thunk": @html.memo(0, _ => {
+      computes.value += 1
+      @html.fragment([
+        span(id="shared-thunk", "thunk"),
+        input(placeholder="Thunk draft"),
+      ])
+    }),
+    "alias-a": shared_input,
+    "alias-b": shared_input,
+  }
+  let content = state.view(state => {
+    let order = [
+      "element", "text", "fragment", "empty", "thunk", "alias-a", "alias-b",
+    ]
+    let order = if state.reversed { order.rev() } else { order }
+    let children : Map[String, Html] = Map([])
+    for key in order {
+      if state.shown || (key != "fragment" && key != "empty" && key != "thunk") {
+        children[key] = shared[key]
+      }
+    }
+    if state.trailing {
+      children["after"] = span(id="shared-after", "after")
+    }
+    div([
+      button(
+        on_click=update(s => { ..s, tick: s.tick + 1, }),
+        "Refresh shared rows",
+      ),
+      button(
+        on_click=update(s => { ..s, reversed: !s.reversed, }),
+        "Reverse shared rows",
+      ),
+      button(
+        on_click=update(s => { ..s, shown: !s.shown, }),
+        "Toggle shared ranges",
+      ),
+      button(
+        on_click=update(s => { ..s, trailing: !s.trailing, }),
+        "Toggle shared tail",
+      ),
+      p(id="shared-tick", "\{state.tick}"),
+      div(id="shared-stage", children),
+    ])
+  })
+  content.map2(counter, (content, counter) => div([content, counter]))
+}

--- a/e2e/apps/memo/physical_nodes.mbt
+++ b/e2e/apps/memo/physical_nodes.mbt
@@ -1,0 +1,102 @@
+///|
+priv struct PhysicalNodesState {
+  choice : Int
+  revision : Int
+} derive(Eq)
+
+///|
+fn physical_nodes(
+  value : String,
+  select : Emit[String],
+  computes : RenderCounter,
+) -> Array[Html] {
+  [
+    button(
+      id="physical-element",
+      title=value,
+      on_click=select("element \{value}"),
+      "element \{value}",
+    ),
+    @html.text("text \{value}"),
+    @html.fragment([
+      span(id="physical-first", "first \{value}"),
+      span(id="physical-second", "second \{value}"),
+    ]),
+    @html.memo_by(
+      value,
+      value => {
+        computes.value += 1
+        button(
+          id="physical-thunk",
+          on_click=select("thunk \{value}"),
+          "thunk \{value}",
+        )
+      },
+      by=value => if value == "A" { 0 } else { 1 },
+    ),
+  ]
+}
+
+///|
+fn physical_nodes_app() -> Val[Html] {
+  let (state, set_state) = @rabbita.create_variable(PhysicalNodesState::{
+    choice: 0,
+    revision: 0,
+  })
+  let choose = set_state.map(choice => {
+    state => { choice, revision: state.revision + 1, }
+  })
+  let (selected, set_selected) = @rabbita.create_variable("")
+  let select = set_selected.map(value => _ => value)
+  let (computes, counter) = render_counter("physical")
+  let a = physical_nodes("A", select, computes)
+  let b = physical_nodes("B", select, computes)
+  let empty = @html.fragment([])
+  let replacements = [
+    span(id="physical-element", "replacement element"),
+    span(id="physical-text-replacement", "replacement text"),
+    @html.text("replacement fragment"),
+    span(id="physical-thunk-replacement", "replacement thunk"),
+  ]
+  let html_svg = @html.svg(id="physical-svg", ([] : Array[Html]))
+  let svg = @svg.svg(id="physical-svg", [])
+  // The parent always renders on refresh, even when its children reuse a VNode.
+  let content = state.view(state => {
+    let nodes = match state.choice {
+      0 => a
+      1 => b
+      2 => physical_nodes("A", select, computes)
+      3 => [empty, empty, empty, empty]
+      _ => replacements
+    }
+    div([
+      p(id="physical-revision", "\{state.revision}"),
+      button(
+        on_click=set_state(state => { ..state, revision: state.revision + 1, }),
+        "Reuse nodes",
+      ),
+      button(on_click=choose(0), "Use A"),
+      button(on_click=choose(1), "Use B"),
+      button(on_click=choose(2), "Use fresh A"),
+      button(on_click=choose(3), "Use empty fragments"),
+      button(on_click=choose(4), "Replace node kinds"),
+      div(id="physical-element-stage", nodes[0]),
+      div(id="physical-text-stage", nodes[1]),
+      div(id="physical-fragment-stage", [
+        span(id="physical-before", "before|"),
+        nodes[2],
+        span(id="physical-after", "|after"),
+      ]),
+      div(id="physical-thunk-stage", nodes[3]),
+      if state.choice == 1 {
+        svg
+      } else {
+        html_svg
+      },
+    ])
+  })
+  let selection = selected.view(selected => p(id="physical-selected", selected))
+  content.map3(counter, selection, (content, counter, selection) => {
+    div([content, counter, selection])
+  })
+}

--- a/e2e/tests/counter.spec.ts
+++ b/e2e/tests/counter.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('counter increments and decrements', async ({ page }) => {
+test('counter updates beside a shared subtree without diffing it', async ({ page }) => {
   await page.goto('/');
 
   const count = page.getByRole('heading', { level: 1 });
@@ -8,10 +8,26 @@ test('counter increments and decrements', async ({ page }) => {
   const decrement = page.getByRole('button', { name: '-', exact: true });
 
   await expect(count).toHaveText('0');
+  const actions = page.locator('.actions');
+  await actions.evaluate((element: HTMLElement) => {
+    const style = element.style;
+    let reads = 0;
+    element.dataset.styleReads = '0';
+    // diff_props reads style even when every property is unchanged.
+    Object.defineProperty(element, 'style', {
+      configurable: true,
+      get() {
+        element.dataset.styleReads = String(++reads);
+        return style;
+      },
+    });
+  });
 
   await increment.click();
   await expect(count).toHaveText('1');
+  await expect(actions).toHaveAttribute('data-style-reads', '0');
 
   await decrement.click();
   await expect(count).toHaveText('0');
+  await expect(actions).toHaveAttribute('data-style-reads', '0');
 });

--- a/e2e/tests/memo.physical-document.spec.ts
+++ b/e2e/tests/memo.physical-document.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+async function settleFrame(page: Page) {
+  await page.evaluate(() => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  }));
+}
+
+async function countStyleReads(element: Locator) {
+  await element.evaluate((node) => {
+    const element = node as HTMLElement;
+    const style = element.style;
+    element.dataset.styleReads = '0';
+    Object.defineProperty(element, 'style', {
+      get() {
+        element.dataset.styleReads = String(Number(element.dataset.styleReads) + 1);
+        return style;
+      },
+    });
+  });
+}
+
+test('container roots skip identical references and cache each replacement', async ({ page }) => {
+  await page.goto('/?physical-root');
+  await settleFrame(page);
+  const root = page.locator('#physical-root');
+  await countStyleReads(root);
+  for (const [value, reads] of [['A', 0], ['B', 1], ['B', 1], ['A', 2], ['A', 2]] as const) {
+    await page.getByRole('button', { name: 'Advance root', exact: true }).click();
+    await settleFrame(page);
+    await expect(page.locator('#physical-root-value')).toHaveText(value);
+    await expect(root).toHaveAttribute('data-style-reads', String(reads));
+  }
+});
+
+for (const markers of [true, false]) {
+  test(`hydrated document roots and shared nodes retain their caches with ${markers ? 'existing' : 'missing'} fragment markers`, async ({ page }) => {
+    // Serve actual pre-rendered nodes before the application module hydrates them.
+    const fragment = '<span id="hydrated-fragment">fragment</span>';
+    await page.route('**/?physical-document', (route) => route.fulfill({
+      contentType: 'text/html',
+      body: `<!doctype html><html><head><title>Physical document 0</title></head><body>` +
+        `<button>Refresh document</button><button>Update document</button>` +
+        `<p id="document-version">revision: 0</p>` +
+        `<div id="hydrated-element">element A</div>shared text` +
+        (markers ? `<!--[-->${fragment}<!--]-->` : fragment) +
+        `<div id="hydrated-thunk">thunk</div>` +
+        `<script>
+          document.documentElement.physicalSeed = {
+            element: document.getElementById('hydrated-element'),
+            text: [...document.body.childNodes].find(node => node.nodeType === 3 && node.nodeValue === 'shared text'),
+            fragment: document.getElementById('hydrated-fragment'),
+            thunk: document.getElementById('hydrated-thunk'),
+          };
+        </script><script type="module" src="/index.js"></script></body></html>`,
+    }));
+    await page.goto('/?physical-document');
+    await expect(page.locator('html')).toHaveId('physical-hydrated');
+    await settleFrame(page);
+
+    expect(await page.evaluate(() => {
+      const seed = (document.documentElement as HTMLElement & {
+        physicalSeed: Record<string, Node>;
+      }).physicalSeed;
+      return {
+        element: seed.element === document.getElementById('hydrated-element'),
+        text: seed.text.isConnected,
+        fragment: seed.fragment === document.getElementById('hydrated-fragment'),
+        thunk: seed.thunk === document.getElementById('hydrated-thunk'),
+        markers: [...document.body.childNodes]
+          .filter(node => node.nodeType === 8)
+          .map(node => node.nodeValue),
+      };
+    })).toEqual({ element: true, text: true, fragment: markers, thunk: true, markers: ['[', ']'] });
+    await expect(page.locator('#hydrated-fragment')).toHaveCount(1);
+    await expect(page.locator('#hydrated-fragment')).toHaveText('fragment');
+
+    const html = page.locator('html');
+    const element = page.locator('#hydrated-element');
+    const sharedFragment = page.locator('#hydrated-fragment');
+    await countStyleReads(html);
+    await countStyleReads(element);
+    await countStyleReads(sharedFragment);
+
+    await page.getByRole('button', { name: 'Refresh document', exact: true }).click();
+    await settleFrame(page);
+    await expect(html).toHaveAttribute('data-style-reads', '0');
+
+    for (const [revision, value, reads] of [[1, 'A', 0], [2, 'B', 1], [3, 'B', 1], [4, 'A', 2]] as const) {
+      await page.getByRole('button', { name: 'Update document', exact: true }).click();
+      await expect(page.locator('#document-version')).toHaveText(`revision: ${revision}`);
+      await expect(page).toHaveTitle(`Physical document ${revision}`);
+      await expect(element).toHaveText(`element ${value}`);
+      await expect(html).toHaveAttribute('data-style-reads', String(revision));
+      await expect(element).toHaveAttribute('data-style-reads', String(reads));
+      await expect(sharedFragment).toHaveAttribute('data-style-reads', '0');
+      await page.getByRole('button', { name: 'Refresh document', exact: true }).click();
+      await settleFrame(page);
+      await expect(html).toHaveAttribute('data-style-reads', String(revision));
+    }
+  });
+}

--- a/e2e/tests/memo.physical-keyed.spec.ts
+++ b/e2e/tests/memo.physical-keyed.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+async function expectComputes(page: Page, expected: number) {
+  const reading = page.locator('#count-shared_keyed-reading');
+  const previous = Number(await reading.innerText());
+  await page.getByRole('button', { name: 'Read shared_keyed count', exact: true }).click();
+  await expect(reading).toHaveText(String(previous + 1));
+  await expect(page.locator('#count-shared_keyed')).toHaveText(String(expected));
+}
+
+async function expectBoundaries(stage: Locator, count: number) {
+  await expect.poll(() => stage.evaluate((element) => Array.from(element.childNodes)
+    .filter((node) => node.nodeType === Node.COMMENT_NODE)
+    .map((node) => node.nodeValue))).toEqual(Array.from({ length: count }, () => ['[', ']']).flat());
+}
+
+test('shared keyed nodes skip diff but still relocate, including empty fragments and aliased VNodes', async ({ page }) => {
+  await page.goto('/?physical-keyed');
+  const stage = page.locator('#shared-stage');
+  await expect(stage).toHaveText('shared textfragmentthunkafter');
+  await expectComputes(page, 1);
+  const original = await stage.evaluateHandle((element) => Array.from(element.childNodes));
+  const drafts = ['Element draft', 'Fragment draft', 'Thunk draft'];
+  for (const draft of drafts) await page.getByPlaceholder(draft, { exact: true }).fill(draft);
+  const aliases = page.getByPlaceholder('Shared alias draft', { exact: true });
+  await aliases.nth(0).fill('alias a');
+  await aliases.nth(1).fill('alias b');
+  await stage.evaluate((element: HTMLElement) => {
+    element.dataset.inserts = '0';
+    element.dataset.styleReads = '0';
+    const insertBefore = element.insertBefore;
+    element.insertBefore = function <T extends Node>(node: T, anchor: Node | null): T {
+      element.dataset.inserts = String(Number(element.dataset.inserts) + 1);
+      return insertBefore.call(this, node, anchor) as T;
+    };
+    for (const child of element.querySelectorAll<HTMLElement>('#shared-element, #shared-fragment, #shared-thunk, .shared-alias')) {
+      const style = child.style;
+      Object.defineProperty(child, 'style', {
+        configurable: true,
+        get() {
+          element.dataset.styleReads = String(Number(element.dataset.styleReads) + 1);
+          return style;
+        },
+      });
+    }
+  });
+
+  await page.getByRole('button', { name: 'Refresh shared rows', exact: true }).click();
+  await expect(page.locator('#shared-tick')).toHaveText('1');
+  await expect(stage).toHaveAttribute('data-inserts', '0');
+  await expect(stage).toHaveAttribute('data-style-reads', '0');
+
+  for (const reversed of [true, false]) {
+    await page.getByRole('button', { name: 'Reverse shared rows', exact: true }).click();
+    await expect(stage).toHaveText(reversed ? 'thunkfragmentshared textafter' : 'shared textfragmentthunkafter');
+    await expectBoundaries(stage, 3);
+    expect(await stage.evaluate((element, nodes) => nodes.every((node) => node.parentNode === element), original)).toBe(true);
+    for (const draft of drafts) await expect(page.getByPlaceholder(draft, { exact: true })).toHaveValue(draft);
+    await expect(aliases.nth(0)).toHaveValue(reversed ? 'alias b' : 'alias a');
+    await expect(aliases.nth(1)).toHaveValue(reversed ? 'alias a' : 'alias b');
+    await expect(stage).toHaveAttribute('data-style-reads', '0');
+    await expectComputes(page, 1);
+  }
+  expect(await stage.evaluate((element, nodes) => nodes.every((node, index) => element.childNodes[index] === node), original)).toBe(true);
+  expect(Number(await stage.getAttribute('data-inserts'))).toBeGreaterThan(0);
+
+  await page.getByRole('button', { name: 'Toggle shared tail', exact: true }).click();
+  await expect(page.locator('#shared-after')).toHaveCount(0);
+  await page.getByRole('button', { name: 'Reverse shared rows', exact: true }).click();
+  await expect(stage).toHaveText('thunkfragmentshared text');
+  await expectBoundaries(stage, 3);
+  await expect(page.getByPlaceholder('Element draft', { exact: true })).toHaveValue('Element draft');
+});
+
+test('removing and remounting shared keyed ranges keeps surviving nodes and creates fresh DOM', async ({ page }) => {
+  await page.goto('/?physical-keyed');
+  const stage = page.locator('#shared-stage');
+  await expectBoundaries(stage, 3);
+  const ranges = await stage.evaluateHandle((element) => Array.from(element.childNodes).filter((node) =>
+    node.nodeType === Node.COMMENT_NODE || (node instanceof HTMLElement &&
+      (node.id === 'shared-fragment' || node.id === 'shared-thunk' || ['Fragment draft', 'Thunk draft'].includes(node.getAttribute('placeholder') ?? '')))));
+  const survivor = page.getByPlaceholder('Element draft', { exact: true });
+  const original = await survivor.elementHandle();
+  await survivor.fill('survives');
+  await page.getByPlaceholder('Fragment draft', { exact: true }).fill('removed draft');
+  await expectComputes(page, 1);
+
+  await page.getByRole('button', { name: 'Toggle shared ranges', exact: true }).click();
+  await expect(stage).toHaveText('shared textafter');
+  await expectBoundaries(stage, 0);
+  expect(await ranges.evaluate((nodes) => nodes.every((node) => !node.isConnected))).toBe(true);
+  await page.getByRole('button', { name: 'Toggle shared ranges', exact: true }).click();
+  await expect(stage).toHaveText('shared textfragmentthunkafter');
+  await expectBoundaries(stage, 3);
+  expect(await ranges.evaluate((nodes) => nodes.every((node) => !node.isConnected))).toBe(true);
+  await expect(page.getByPlaceholder('Fragment draft', { exact: true })).toHaveValue('');
+  await expect(page.getByPlaceholder('Thunk draft', { exact: true })).toHaveValue('');
+  await expect(survivor).toHaveValue('survives');
+  expect(await survivor.evaluate((node, saved) => node === saved, original)).toBe(true);
+  await expectComputes(page, 2);
+});

--- a/e2e/tests/memo.physical-nodes.spec.ts
+++ b/e2e/tests/memo.physical-nodes.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function update(page: Page, action: string) {
+  const revision = page.locator('#physical-revision');
+  const previous = Number(await revision.innerText());
+  await page.getByRole('button', { name: action, exact: true }).click();
+  await expect(revision).toHaveText(String(previous + 1));
+}
+
+async function expectComputes(page: Page, expected: number) {
+  const reading = page.locator('#count-physical-reading');
+  const previous = Number(await reading.innerText());
+  await page.getByRole('button', { name: 'Read physical count', exact: true }).click();
+  await expect(reading).toHaveText(String(previous + 1));
+  await expect(page.locator('#count-physical')).toHaveText(String(expected));
+}
+
+async function expectNodes(page: Page, value: string) {
+  await expect(page.locator('#physical-element')).toHaveText(`element ${value}`);
+  await expect(page.locator('#physical-element')).toHaveAttribute('title', value);
+  await expect(page.locator('#physical-text-stage')).toHaveText(`text ${value}`);
+  await expect(page.locator('#physical-fragment-stage')).toHaveText(`before|first ${value}second ${value}|after`);
+  await expect(page.locator('#physical-thunk')).toHaveText(`thunk ${value}`);
+}
+
+async function watchElementDiff(page: Page) {
+  await page.locator('#physical-element').evaluate((element: HTMLElement) => {
+    const style = element.style;
+    let reads = 0;
+    element.dataset.styleReads = '0';
+    // diff_props reads style even for a structurally identical fresh VNode.
+    Object.defineProperty(element, 'style', {
+      configurable: true,
+      get() {
+        element.dataset.styleReads = String(++reads);
+        return style;
+      },
+    });
+  });
+}
+
+test('shared element, text, fragment and thunk references survive A/A/B/B/A updates', async ({ page }) => {
+  await page.goto('/?physical-nodes');
+  await expectNodes(page, 'A');
+  await expectComputes(page, 1);
+  await watchElementDiff(page);
+  const text = await page.locator('#physical-text-stage').evaluateHandle((stage) => stage.firstChild);
+  const fragmentStart = await page.locator('#physical-fragment-stage').evaluateHandle((stage) => stage.childNodes[1]);
+  let svg = await page.locator('#physical-svg').elementHandle();
+  expect(await svg!.evaluate((node) => node.namespaceURI)).toBe('http://www.w3.org/1999/xhtml');
+
+  for (const [action, value, reads, computes] of [
+    ['Reuse nodes', 'A', 0, 1],
+    ['Use B', 'B', 1, 2],
+    ['Reuse nodes', 'B', 1, 2],
+    ['Use A', 'A', 2, 3],
+  ] as const) {
+    await update(page, action);
+    await expectNodes(page, value);
+    await expect(page.locator('#physical-element')).toHaveAttribute('data-style-reads', String(reads));
+    await expectComputes(page, computes);
+    expect(await page.locator('#physical-text-stage').evaluate((stage, original) => stage.firstChild === original, text)).toBe(true);
+    expect(await page.locator('#physical-fragment-stage').evaluate((stage, original) => stage.childNodes[1] === original, fragmentStart)).toBe(true);
+    for (const kind of ['element', 'thunk']) {
+      await page.locator(`#physical-${kind}`).click();
+      await expect(page.locator('#physical-selected')).toHaveText(`${kind} ${value}`);
+    }
+    const namespace = value === 'A' ? 'http://www.w3.org/1999/xhtml' : 'http://www.w3.org/2000/svg';
+    expect(await page.locator('#physical-svg').evaluate((node) => node.namespaceURI)).toBe(namespace);
+    expect(await svg!.evaluate((node) => node.isConnected)).toBe(action === 'Reuse nodes');
+    svg = await page.locator('#physical-svg').elementHandle();
+  }
+});
+
+test('fresh equal nodes still diff properties while equal text and same-hash thunks preserve their DOM', async ({ page }) => {
+  await page.goto('/?physical-nodes');
+  await expectNodes(page, 'A');
+  await watchElementDiff(page);
+  const text = await page.locator('#physical-text-stage').evaluateHandle((stage) => stage.firstChild);
+  const thunk = await page.locator('#physical-thunk').elementHandle();
+
+  for (const [action, reads] of [['Use fresh A', 1], ['Reuse nodes', 2], ['Use A', 3], ['Reuse nodes', 3]] as const) {
+    await update(page, action);
+    await expectNodes(page, 'A');
+    await expect(page.locator('#physical-element')).toHaveAttribute('data-style-reads', String(reads));
+    await expectComputes(page, 1);
+    expect(await page.locator('#physical-text-stage').evaluate((stage, original) => stage.firstChild === original, text)).toBe(true);
+    expect(await page.locator('#physical-thunk').evaluate((node, original) => node === original, thunk)).toBe(true);
+  }
+
+  await update(page, 'Use B');
+  await expectNodes(page, 'B');
+  await expectComputes(page, 2);
+  await page.locator('#physical-thunk').click();
+  await expect(page.locator('#physical-selected')).toHaveText('thunk B');
+});
+
+test('shared nodes can change tag or kind, become empty fragments and restore their full ranges', async ({ page }) => {
+  await page.goto('/?physical-nodes');
+  await expectNodes(page, 'A');
+  const element = await page.locator('#physical-element').elementHandle();
+  const text = await page.locator('#physical-text-stage').evaluateHandle((stage) => stage.firstChild);
+  const fragment = await page.locator('#physical-fragment-stage').evaluateHandle((stage) => stage.childNodes[1]);
+  const thunk = await page.locator('#physical-thunk').elementHandle();
+
+  await update(page, 'Replace node kinds');
+  await expect(page.locator('#physical-element-stage')).toHaveText('replacement element');
+  expect(await page.locator('#physical-element').evaluate((node) => node.tagName)).toBe('SPAN');
+  await expect(page.locator('#physical-text-replacement')).toHaveText('replacement text');
+  await expect(page.locator('#physical-fragment-stage')).toHaveText('before|replacement fragment|after');
+  await expect(page.locator('#physical-thunk-replacement')).toHaveText('replacement thunk');
+  for (const original of [element!, text, fragment, thunk!]) {
+    expect(await original.evaluate((node) => node!.isConnected)).toBe(false);
+  }
+
+  await update(page, 'Use A');
+  await expectNodes(page, 'A');
+  await expectComputes(page, 2);
+  const boundary = await page.locator('#physical-fragment-stage').evaluateHandle((stage) => stage.childNodes[1]);
+  await update(page, 'Use empty fragments');
+  await expect(page.locator('#physical-fragment-stage')).toHaveText('before||after');
+  for (const kind of ['element', 'text', 'thunk']) {
+    await expect(page.locator(`#physical-${kind}-stage`)).toBeEmpty();
+  }
+  const fragmentStage = page.locator('#physical-fragment-stage');
+  expect(await fragmentStage.evaluate((stage, original) => stage.childNodes[1] === original, boundary)).toBe(true);
+  expect(await fragmentStage.evaluate((stage) => Array.from(stage.childNodes).map((node) => node.nodeType))).toEqual([1, 8, 8, 1]);
+
+  await update(page, 'Reuse nodes');
+  expect(await fragmentStage.evaluate((stage, original) => stage.childNodes[1] === original, boundary)).toBe(true);
+  await expectComputes(page, 2);
+  await update(page, 'Use B');
+  await expectNodes(page, 'B');
+  await expectComputes(page, 3);
+  expect(await fragmentStage.evaluate((stage) => Array.from(stage.childNodes).map((node) => node.nodeType))).toEqual([1, 8, 1, 1, 8, 1]);
+  await update(page, 'Use A');
+  await expectNodes(page, 'A');
+  await expectComputes(page, 4);
+});

--- a/rabbita/internal/vdom/diff.mbt
+++ b/rabbita/internal/vdom/diff.mbt
@@ -22,19 +22,37 @@ priv struct IProps {
 ///|
 #cfg(target="js")
 priv enum INode {
-  Elem(String, IProps, Children[INode], namespace_uri~ : String?, @dom.Element)
-  Text(String, @dom.Element)
-  Frag(Array[INode], @dom.Comment, @dom.Comment)
-  Thunk(Int, INode)
+  Elem(
+    String,
+    IProps,
+    Children[INode],
+    namespace_uri~ : String?,
+    @dom.Element,
+    VNode
+  )
+  Text(String, @dom.Element, VNode)
+  Frag(Array[INode], @dom.Comment, @dom.Comment, VNode)
+  Thunk(Int, INode, VNode)
+}
+
+///|
+#cfg(target="js")
+fn INode::vnode(self : Self) -> VNode {
+  match self {
+    Elem(_, _, _, _, vnode, ..)
+    | Text(_, _, vnode)
+    | Frag(_, _, _, vnode)
+    | Thunk(_, _, vnode) => vnode
+  }
 }
 
 ///|
 #cfg(target="js")
 fn INode::start(self : Self) -> @dom.Node {
   match self {
-    Elem(_, _, _, element, ..) | Text(_, element) => element.as_node()
-    Thunk(_, node) => node.start()
-    Frag(_, start, _) => start.as_node()
+    Elem(_, _, _, element, _, ..) | Text(_, element, _) => element.as_node()
+    Thunk(_, node, _) => node.start()
+    Frag(_, start, _, _) => start.as_node()
   }
 }
 
@@ -42,9 +60,9 @@ fn INode::start(self : Self) -> @dom.Node {
 #cfg(target="js")
 fn INode::end(self : Self) -> @dom.Node {
   match self {
-    Elem(_, _, _, element, ..) | Text(_, element) => element.as_node()
-    Thunk(_, node) => node.end()
-    Frag(_, _, end) => end.as_node()
+    Elem(_, _, _, element, _, ..) | Text(_, element, _) => element.as_node()
+    Thunk(_, node, _) => node.end()
+    Frag(_, _, end, _) => end.as_node()
   }
 }
 
@@ -65,10 +83,10 @@ fn INode::needs_relocation(
 #cfg(target="js")
 fn INode::remove(self : Self, parent : @dom.Node) -> Unit {
   match self {
-    Elem(_, _, _, element, ..) | Text(_, element) =>
+    Elem(_, _, _, element, _, ..) | Text(_, element, _) =>
       parent.remove_child(element.as_node())
-    Thunk(_, node) => node.remove(parent)
-    Frag(_, start, end) => {
+    Thunk(_, node, _) => node.remove(parent)
+    Frag(_, start, end, _) => {
       let start = start.as_node()
       let end = end.as_node()
       while start.get_next_sibling().to_option() is Some(node) &&
@@ -90,10 +108,10 @@ fn INode::relocate(
 ) -> Unit {
   guard self.needs_relocation(before) else { return }
   match self {
-    Elem(_, _, _, element, ..) | Text(_, element) =>
+    Elem(_, _, _, element, _, ..) | Text(_, element, _) =>
       parent.insert_before(element.as_node(), before)
-    Thunk(_, node) => node.relocate(parent, before)
-    Frag(_, start, end) => {
+    Thunk(_, node, _) => node.relocate(parent, before)
+    Frag(_, start, end, _) => {
       {
         guard! start.get_parent_node().to_option() is Some(a)
         guard! end.get_parent_node().to_option() is Some(b)
@@ -214,13 +232,13 @@ fn VNode::insert(
     Text(text) => {
       let element = @dom.document().create_text_node(text)
       parent.insert_before(element.as_node(), before)
-      Text(text, element)
+      Text(text, element, self)
     }
     Thunk(hash, render) => {
       let node = render().insert(
         scheduler, captured_link_listener, parent, before,
       )
-      Thunk(hash, node)
+      Thunk(hash, node, self)
     }
     Frag(children) => {
       let document = @dom.document()
@@ -238,7 +256,7 @@ fn VNode::insert(
       })
       fragment.append_child(end.as_node())
       parent.insert_before(fragment.as_node(), before)
-      Frag(children, start, end)
+      Frag(children, start, end, self)
     }
     Elem(tag, props, children, namespace_uri~) => {
       let rendered_tag = rendered_tag(tag)
@@ -259,7 +277,7 @@ fn VNode::insert(
       }
       reapply_child_sensitive_properties(element, tag, props.props)
       parent.insert_before(node, before)
-      Elem(tag, props, children, namespace_uri~, element)
+      Elem(tag, props, children, namespace_uri~, element, self)
     }
   }
 }
@@ -268,16 +286,16 @@ fn VNode::insert(
 #cfg(target="js")
 fn INode::to_vnode(self : Self) -> VNode {
   match self {
-    Elem(tag, mounted_props, children, namespace_uri~, _) =>
+    Elem(tag, mounted_props, children, namespace_uri~, _, _) =>
       Elem(
         tag,
         mounted_props.props,
         children.map(child => child.to_vnode()),
         namespace_uri~,
       )
-    Text(text, _) => Text(text)
-    Frag(children, _, _) => Frag(children.map(child => child.to_vnode()))
-    Thunk(_, node) => node.to_vnode()
+    Text(text, _, _) => Text(text)
+    Frag(children, _, _, _) => Frag(children.map(child => child.to_vnode()))
+    Thunk(_, node, _) => node.to_vnode()
   }
 }
 
@@ -386,8 +404,8 @@ pub fn VDom::initialize(
         props,
         Array(
           [
-            Elem("head", head_props, head_children, ..),
-            Elem("body", body_props, body_children, ..),
+            Elem("head", head_props, head_children, ..) as head_vnode,
+            Elem("body", body_props, body_children, ..) as body_vnode,
           ]
         ),
         namespace_uri=None
@@ -404,7 +422,14 @@ pub fn VDom::initialize(
           scheduler,
           captured_link_listener,
         )
-        INode::Elem("head", props, children, namespace_uri=None, element)
+        INode::Elem(
+          "head",
+          props,
+          children,
+          namespace_uri=None,
+          element,
+          head_vnode,
+        )
       }
       let body = {
         let element = @dom.document().get_body().unwrap().as_element()
@@ -417,7 +442,14 @@ pub fn VDom::initialize(
           scheduler,
           captured_link_listener,
         )
-        INode::Elem("body", props, children, namespace_uri=None, element)
+        INode::Elem(
+          "body",
+          props,
+          children,
+          namespace_uri=None,
+          element,
+          body_vnode,
+        )
       }
 
       let html = @dom.document().get_document_element().unwrap()
@@ -430,6 +462,7 @@ pub fn VDom::initialize(
         Array([head, body]),
         html,
         namespace_uri=None,
+        vnode,
       )
       VDom::{ target_element: None, inode, captured_link_listener, }
     }
@@ -459,6 +492,9 @@ fn diff_document(
   container? : @dom.Element,
   captured_link_listener~ : @dom.Listener,
 ) -> INode {
+  if physical_equal(old.vnode(), new) {
+    return old
+  }
   match (container, old, new) {
     (
       None,
@@ -467,20 +503,21 @@ fn diff_document(
         old_props,
         Array(
           [
-            Elem("head", old_head_props, old_head_children, head_element, ..),
-            Elem("body", old_body_props, old_body_children, body_element, ..),
+            Elem("head", old_head_props, old_head_children, head_element, _, ..),
+            Elem("body", old_body_props, old_body_children, body_element, _, ..),
           ]
         ),
         html_element,
-        namespace_uri=None
+        namespace_uri=None,
+        _
       ),
       Elem(
         "html",
         new_props,
         Array(
           [
-            Elem("head", new_head_props, new_head_children, ..),
-            Elem("body", new_body_props, new_body_children, ..),
+            Elem("head", new_head_props, new_head_children, ..) as head_vnode,
+            Elem("body", new_body_props, new_body_children, ..) as body_vnode,
           ]
         ),
         namespace_uri=None
@@ -499,7 +536,14 @@ fn diff_document(
           head_element.as_node(),
           null(),
         )
-        INode::Elem("head", props, children, namespace_uri=None, head_element)
+        INode::Elem(
+          "head",
+          props,
+          children,
+          namespace_uri=None,
+          head_element,
+          head_vnode,
+        )
       }
       let body = {
         let props = diff_props(
@@ -513,9 +557,23 @@ fn diff_document(
           body_element.as_node(),
           null(),
         )
-        INode::Elem("body", props, children, namespace_uri=None, body_element)
+        INode::Elem(
+          "body",
+          props,
+          children,
+          namespace_uri=None,
+          body_element,
+          body_vnode,
+        )
       }
-      Elem("html", props, Array([head, body]), html_element, namespace_uri=None)
+      Elem(
+        "html",
+        props,
+        Array([head, body]),
+        html_element,
+        namespace_uri=None,
+        new,
+      )
     }
     (Some(container), old, new) =>
       diff_node(
@@ -541,9 +599,12 @@ fn diff_node(
   parent : @dom.Node,
   anchor : @js.Nullable[@dom.Node],
 ) -> INode {
+  if physical_equal(old.vnode(), new) {
+    return old
+  }
   match (old, new) {
     (
-      Elem(tag1, props1, children1, namespace_uri=ns1, element),
+      Elem(tag1, props1, children1, namespace_uri=ns1, element, _),
       Elem(tag2, props2, children2, namespace_uri=ns2),
     ) =>
       if tag1 != tag2 || ns1 != ns2 {
@@ -560,15 +621,15 @@ fn diff_node(
           null(),
         )
         reapply_child_sensitive_properties(element, tag2, props.props)
-        Elem(tag2, props, children, namespace_uri=ns2, element)
+        Elem(tag2, props, children, namespace_uri=ns2, element, new)
       }
-    (Text(text1, element), Text(text2)) => {
+    (Text(text1, element, _), Text(text2)) => {
       if text1 != text2 {
         element.set_node_value(@js.Nullable::from_option(Some(text2)))
       }
-      Text(text2, element)
+      Text(text2, element, new)
     }
-    (Frag(children1, start, end), Frag(children2)) => {
+    (Frag(children1, start, end, _), Frag(children2)) => {
       let children = diff_children(
         Array(children1),
         Array(children2),
@@ -578,9 +639,9 @@ fn diff_node(
         nullable(end.as_node()),
       )
       guard! children is Array(children)
-      Frag(children, start, end)
+      Frag(children, start, end, new)
     }
-    (Thunk(hash1, node) as old, Thunk(hash2, render)) =>
+    (Thunk(hash1, node, _) as old, Thunk(hash2, render)) =>
       if hash1 == hash2 {
         old
       } else {
@@ -588,7 +649,7 @@ fn diff_node(
         let node = diff_node(
           node, vnode, scheduler, captured_link_listener, parent, anchor,
         )
-        Thunk(hash2, node)
+        Thunk(hash2, node, new)
       }
     (_, _) => {
       old.remove(parent)

--- a/rabbita/internal/vdom/hydrate.mbt
+++ b/rabbita/internal/vdom/hydrate.mbt
@@ -156,6 +156,7 @@ fn hydrate_existing_element(
   scheduler : &Scheduler,
   captured_link_listener : @dom.Listener,
   allow_skip_children~ : Bool,
+  vnode : VNode,
 ) -> INode {
   let mounted_props = insert_props(
     element, tag, props, scheduler, captured_link_listener,
@@ -180,7 +181,7 @@ fn hydrate_existing_element(
     mounted
   }
   reapply_child_sensitive_properties(element, tag, mounted_props.props)
-  Elem(tag, mounted_props, mounted_children, namespace_uri~, element)
+  Elem(tag, mounted_props, mounted_children, namespace_uri~, element, vnode)
 }
 
 ///|
@@ -193,6 +194,7 @@ fn hydrate_fragment(
   current : @dom.Node?,
   boundary~ : @dom.Node?,
   allow_skip~ : Bool,
+  vnode : VNode,
 ) -> (INode, @dom.Node?) {
   fn find_fragment_start(current : @dom.Node?) -> @dom.Comment? {
     let mut current = current
@@ -252,15 +254,10 @@ fn hydrate_fragment(
       end
     }
     let children = if mounted is Array(children) { children } else { [] }
-    (Frag(children, start, end), end.get_next_sibling().to_option())
+    (Frag(children, start, end, vnode), end.get_next_sibling().to_option())
   } else {
     recover_mismatch(
-      Frag(children),
-      scheduler,
-      captured_link_listener,
-      parent,
-      current,
-      boundary,
+      vnode, scheduler, captured_link_listener, parent, current, boundary,
     )
   }
 }
@@ -287,7 +284,7 @@ fn hydrate_node(
         boundary~,
         allow_skip~,
       )
-      (Thunk(hash, inode), next)
+      (Thunk(hash, inode, vnode), next)
     }
     Frag(children) =>
       hydrate_fragment(
@@ -298,6 +295,7 @@ fn hydrate_node(
         current,
         boundary~,
         allow_skip~,
+        vnode,
       )
     Text(text) =>
       if find_hydratable(vnode, current, boundary, allow_skip~) is Some(node) {
@@ -305,7 +303,7 @@ fn hydrate_node(
           node.set_node_value(nullable(text))
         }
         let element : @dom.Element = @js.Value::cast_from(node).cast()
-        (Text(text, element), node.get_next_sibling().to_option())
+        (Text(text, element, vnode), node.get_next_sibling().to_option())
       } else {
         recover_mismatch(
           vnode, scheduler, captured_link_listener, parent, current, boundary,
@@ -323,6 +321,7 @@ fn hydrate_node(
           scheduler,
           captured_link_listener,
           allow_skip_children=false,
+          vnode,
         )
         (inode, node.get_next_sibling().to_option())
       } else {
@@ -405,13 +404,13 @@ fn hydrate_root(
             head_props,
             head_children,
             namespace_uri=head_namespace_uri
-          ),
+          ) as head_vnode,
           Elem(
             "body",
             body_props,
             body_children,
             namespace_uri=body_namespace_uri
-          ),
+          ) as body_vnode,
         ]
       ),
       ..
@@ -432,6 +431,7 @@ fn hydrate_root(
         scheduler,
         captured_link_listener,
         allow_skip_children=true,
+        head_vnode,
       )
       let body = hydrate_existing_element(
         "body",
@@ -442,8 +442,16 @@ fn hydrate_root(
         scheduler,
         captured_link_listener,
         allow_skip_children=true,
+        body_vnode,
       )
-      Elem("html", html_props, Array([head, body]), html, namespace_uri=None)
+      Elem(
+        "html",
+        html_props,
+        Array([head, body]),
+        html,
+        namespace_uri=None,
+        vnode,
+      )
     }
     _ => panic()
   }

--- a/rabbita/internal/vdom/vdom_relocation_wbtest.mbt
+++ b/rabbita/internal/vdom/vdom_relocation_wbtest.mbt
@@ -89,8 +89,8 @@ test "diffing unchanged keyed children does not reinsert DOM nodes" {
   parent..append_child(first.as_node()).append_child(second.as_node())
   let old : Children[INode] = Map(
     Map::from_array([
-      ("first", INode::Text("first", first)),
-      ("second", INode::Text("second", second)),
+      ("first", INode::Text("first", first, VNode::text("first"))),
+      ("second", INode::Text("second", second, VNode::text("second"))),
     ]),
   )
   let new : Children[VNode] = Map(
@@ -125,7 +125,10 @@ test "relocate inserts a DOM node when its position differs" {
   let second = document.create_text_node("second")
   parent..append_child(first.as_node()).append_child(second.as_node())
 
-  INode::Text("first", first).relocate(parent.as_node(), null())
+  INode::Text("first", first, VNode::text("first")).relocate(
+    parent.as_node(),
+    null(),
+  )
 
   assert_eq(parent.get_attribute("data-insert-count"), Some("1"))
 }


### PR DESCRIPTION
Reusing the same VNode currently traverses its mounted subtree on each update. Retain the original VNode as a positional field on each INode variant and return the mounted node when `physical_equal` succeeds in node or document diffing. Mounting, updates, and hydration preserve the current reference; keyed relocation still runs after diffing.

Add browser coverage for element, text, fragment, and thunk reference reuse, A/B/A updates, equal content with different references, tag/namespace and node-kind replacement, empty fragments, keyed movement/remounting, shared VNodes under multiple keys, and hydration with existing or missing fragment boundaries. Style-read probes distinguish skipped traversal from a diff that leaves the DOM unchanged. Public interfaces are unchanged.

Validation:
- MoonBit JS type checking, formatting, and interface generation passed.
- Counter and memo Playwright projects: 20 tests passed.
- Root/document tests repeated five times: 15 tests passed.
- Five temporary fault-injection checks were detected: removing the short-circuits, or retaining stale VNode references for each of the four INode variants. The implementation was restored and the 20-test suite passed again.
